### PR TITLE
Handle false values

### DIFF
--- a/src/utils/translation-utils.ts
+++ b/src/utils/translation-utils.ts
@@ -77,7 +77,8 @@ export function findMissingTranslations(
     }
 
     if (typeof details === 'boolean') {
-      if (!targetKeys[key]) {
+      const targetValue = targetKeys[key];
+      if (targetValue === undefined || (typeof targetValue === 'object' && !('value' in targetValue))) {
         missingKeys[key] = {
           value: details,
           sourceKey: key

--- a/tests/utils/translation-utils.test.js
+++ b/tests/utils/translation-utils.test.js
@@ -30,10 +30,14 @@ describe('translation-utils', () => {
       const sourceKeys = {
         'app.utils.show_wizard': true,
         'app.utils.skip_wizard': false,
-        'app.utils.display_help': { value: true }
+        'app.utils.display_help': { value: true },
+        'app.utils.hide_help': { value: false }
       };
 
-      const targetKeys = {};
+      const targetKeys = {
+        'app.utils.skip_wizard': false,
+        'app.utils.hide_help': { value: false }
+      };
 
       const result = findMissingTranslations(sourceKeys, targetKeys);
 
@@ -42,16 +46,14 @@ describe('translation-utils', () => {
           value: true,
           sourceKey: 'app.utils.show_wizard'
         },
-        'app.utils.skip_wizard': {
-          value: false,
-          sourceKey: 'app.utils.skip_wizard'
-        },
         'app.utils.display_help': {
           value: true,
           sourceKey: 'app.utils.display_help'
         }
       });
       expect(result.skippedKeys).toEqual({});
+      expect(result.missingKeys['app.utils.skip_wizard']).toBeUndefined();
+      expect(result.missingKeys['app.utils.hide_help']).toBeUndefined();
     });
 
     it('should skip WIP keys with wip_ prefix', () => {


### PR DESCRIPTION
When there is a false (boolean) value in a target translation, it should not get translated. These should be considered already translated.