### PR TITLE
Support multi language files

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,14 +103,16 @@ This is a beta feature — please report issues.
 
 Some keys shouldn't be translated by LocalHero — for example, Rails validation
 errors served in English by an API, or internal admin strings. Add them to
-`ignoreKeys` in your `localhero.json`:
+`translationFiles.ignoreKeys` in your `localhero.json`:
 
 ```json
 {
-  "ignoreKeys": [
-    "activerecord.errors.*",
-    "admin.internal.*"
-  ]
+  "translationFiles": {
+    "ignoreKeys": [
+      "activerecord.errors.*",
+      "admin.internal.*"
+    ]
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,31 @@ We auto-detect your project during init.
 - **React / Next.js** - JSON translation files
 - **Generic** - any JSON or YAML structure
 
+### Multi-language files (beta)
+
+Some projects keep all locales in one file, with top-level locale keys. Common in Rails apps that co-locate i18n with mailer templates or view components:
+
+```yaml
+en:
+  subject: "You've been invited"
+sv:
+  subject: "Du har blivit inbjuden"
+```
+
+Opt in by adding `multiLanguageFiles: true` to your `localhero.json`:
+
+```json
+"translationFiles": {
+  "paths": ["config/locales/", "apps/"],
+  "pattern": "**/*.{yml,yaml}",
+  "multiLanguageFiles": true
+}
+```
+
+Detection rule: every top-level key in the file must be a configured locale (in `sourceLocale` or `outputLocales`), and there must be at least two. Supported formats: YAML and JSON. PO files are not supported.
+
+This is a beta feature — please report issues.
+
 ## Commands
 
 ### Initialize a Project

--- a/README.md
+++ b/README.md
@@ -99,6 +99,28 @@ Detection rule: every top-level key in the file must be a configured locale (in 
 
 This is a beta feature — please report issues.
 
+## Ignoring keys
+
+Some keys shouldn't be translated by LocalHero — for example, Rails validation
+errors served in English by an API, or internal admin strings. Add them to
+`ignoreKeys` in your `localhero.json`:
+
+```json
+{
+  "ignoreKeys": [
+    "activerecord.errors.*",
+    "admin.internal.*"
+  ]
+}
+```
+
+Matching keys are skipped during `push` and `translate`. Two pattern forms are
+supported: exact names (`foo.bar.baz`) and trailing wildcards (`foo.bar.*`,
+recursive). Use `--verbose` to see a summary of what was ignored.
+
+Not yet supported for `.po` / `.pot` files — those are uploaded unfiltered with
+a warning.
+
 ## Commands
 
 ### Initialize a Project

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ We auto-detect your project during init.
 
 ### Multi-language files (beta)
 
-Some projects keep all locales in one file, with top-level locale keys. Common in Rails apps that co-locate i18n with mailer templates or view components:
+Some projects keep all locales in one file, with top-level locale keys:
 
 ```yaml
 en:
@@ -85,43 +85,21 @@ sv:
   subject: "Du har blivit inbjuden"
 ```
 
-Opt in by adding `multiLanguageFiles: true` to your `localhero.json`:
-
-```json
-"translationFiles": {
-  "paths": ["config/locales/", "apps/"],
-  "pattern": "**/*.{yml,yaml}",
-  "multiLanguageFiles": true
-}
-```
-
-Detection rule: every top-level key in the file must be a configured locale (in `sourceLocale` or `outputLocales`), and there must be at least two. Supported formats: YAML and JSON. PO files are not supported.
-
-This is a beta feature — please report issues.
+Opt in by setting `translationFiles.multiLanguageFiles: true`. YAML and JSON only, not PO. A file is treated as multi-language when every top-level key is a configured locale (source or output), with at least two locales present.
 
 ## Ignoring keys
 
-Some keys shouldn't be translated by LocalHero — for example, Rails validation
-errors served in English by an API, or internal admin strings. Add them to
-`translationFiles.ignoreKeys` in your `localhero.json`:
+Skip keys you don't want translated (e.g. Rails validation errors, internal admin strings) via `translationFiles.ignoreKeys`:
 
 ```json
 {
   "translationFiles": {
-    "ignoreKeys": [
-      "activerecord.errors.*",
-      "admin.internal.*"
-    ]
+    "ignoreKeys": ["activerecord.errors.*", "admin.internal.*"]
   }
 }
 ```
 
-Matching keys are skipped during `push` and `translate`. Two pattern forms are
-supported: exact names (`foo.bar.baz`) and trailing wildcards (`foo.bar.*`,
-recursive). Use `--verbose` to see a summary of what was ignored.
-
-Not yet supported for `.po` / `.pot` files — those are uploaded unfiltered with
-a warning.
+Patterns are exact names or trailing wildcards (`foo.*`, recursive). Matches are skipped during `push` and `translate`; use `--verbose` for a summary. Not supported for `.po` / `.pot` files.
 
 ## Commands
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@localheroai/cli",
-  "version": "0.0.45-multilang.1",
+  "version": "0.0.45-multilang.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@localheroai/cli",
-      "version": "0.0.45-multilang.1",
+      "version": "0.0.45-multilang.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@localheroai/cli",
-  "version": "0.0.44",
+  "version": "0.0.45-multilang.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@localheroai/cli",
-      "version": "0.0.44",
+      "version": "0.0.45-multilang.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@localheroai/cli",
-  "version": "0.0.45-multilang.0",
+  "version": "0.0.45-multilang.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@localheroai/cli",
-      "version": "0.0.45-multilang.0",
+      "version": "0.0.45-multilang.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@localheroai/cli",
-  "version": "0.0.45-multilang.1",
+  "version": "0.0.45-multilang.2",
   "description": "CLI tool for managing translations with LocalHero.ai",
   "homepage": "https://localhero.ai",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@localheroai/cli",
-  "version": "0.0.45-multilang.0",
+  "version": "0.0.45-multilang.1",
   "description": "CLI tool for managing translations with LocalHero.ai",
   "homepage": "https://localhero.ai",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@localheroai/cli",
-  "version": "0.0.44",
+  "version": "0.0.45-multilang.0",
   "description": "CLI tool for managing translations with LocalHero.ai",
   "homepage": "https://localhero.ai",
   "repository": {

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -2,6 +2,23 @@ import { ApiResponseError } from '../types/index.js';
 
 const DEFAULT_API_HOST = 'https://api.localhero.ai';
 
+function friendlyServerError(status: number): string {
+  if (status >= 500 && status < 600) {
+    if (status === 502 || status === 503 || status === 504) {
+      return 'Our server is temporarily unavailable. Please try again in a minute. ' +
+             'If this keeps happening, email us at hi@localhero.ai.';
+    }
+    return 'Something went wrong on our end (HTTP ' + status + '). ' +
+           'Please try again shortly. If this keeps happening, email us at hi@localhero.ai.';
+  }
+  if (status >= 400 && status < 500) {
+    return 'The request was rejected (HTTP ' + status + '). ' +
+           'If this was unexpected, please email us at hi@localhero.ai.';
+  }
+  return 'Received an unexpected response from the server (HTTP ' + status + '). ' +
+         'If this keeps happening, please email us at hi@localhero.ai.';
+}
+
 // Retry configuration for network errors
 const RETRY_CONFIG = {
   maxRetries: 5,
@@ -106,15 +123,16 @@ export async function apiRequest<T = any>(endpoint: string, options: ApiRequestO
 
   const response = await fetchWithRetry(url, fetchOptions);
 
-  let data: any;
-  try {
-    data = await response.json();
-  } catch (error) {
-    const parseError = error as Error;
-    const message = 'Failed to parse API response. Error: ' + error;
-    parseError.message = message;
-    (parseError as any).cliErrorMessage = message;
-    throw parseError;
+  const rawBody = await response.text();
+
+  let data: any = null;
+  let parseError: Error | null = null;
+  if (rawBody.length > 0) {
+    try {
+      data = JSON.parse(rawBody);
+    } catch (err) {
+      parseError = err as Error;
+    }
   }
 
   if (!response.ok) {
@@ -157,12 +175,30 @@ export async function apiRequest<T = any>(endpoint: string, options: ApiRequestO
       cliErrorMessage = `Server error: ${message}`;
     }
 
+    if (!data) {
+      const friendlyMessage = friendlyServerError(response.status);
+      const error = new ApiResponseError(friendlyMessage, {
+        code: 'server_error',
+        details: { status: response.status }
+      });
+      throw error;
+    }
+
     const error = new ApiResponseError(message, {
       code: data?.error?.code || 'API_ERROR',
       details: data?.error?.details || null,
       data,
       cliErrorMessage
     });
+    throw error;
+  }
+
+  if (parseError) {
+    const error = new ApiResponseError(
+      'We received an unexpected response from the server. ' +
+      'If this keeps happening, please email us at hi@localhero.ai.',
+      { code: 'invalid_response', details: { parseError: parseError.message } }
+    );
     throw error;
   }
 

--- a/src/api/imports.ts
+++ b/src/api/imports.ts
@@ -10,6 +10,7 @@ export interface TranslationPayload {
   filename: string;
   content: string;
   keys?: Array<{ name: string; context: string | null }>;
+  multi_language?: boolean;
 }
 
 export interface CreateImportParams {

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -2,6 +2,8 @@ import chalk from 'chalk';
 import { importService as defaultImportService } from '../utils/import-service.js';
 import { createPromptService, ConfirmOptions, defaultInquirerAdapter } from '../utils/prompt-service.js';
 import { bulkDeleteKeys as defaultBulkDeleteKeys } from '../api/keys.js';
+import { createIgnoreMatcher, IgnoreSummary } from '../utils/ignore-keys.js';
+import { logIgnoreSummary } from '../utils/ignore-keys-logging.js';
 import { ProjectConfig, PrunableKey, ImportFile } from '../types/index.js';
 
 const MAX_KEYS_TO_DISPLAY = 10;
@@ -22,6 +24,7 @@ interface PushResult {
     target: ImportFile[];
   };
   prunable_keys?: PrunableKey[];
+  ignoreSummary?: IgnoreSummary;
 }
 
 interface PushDependencies {
@@ -29,7 +32,12 @@ interface PushDependencies {
     pushTranslations: (
       config: ProjectConfig,
       basePath?: string,
-      options?: { force?: boolean; verbose?: boolean; prune?: boolean }
+      options?: {
+        force?: boolean;
+        verbose?: boolean;
+        prune?: boolean;
+        ignoreMatcher?: (keyName: string) => boolean;
+      }
     ) => Promise<PushResult>;
   };
   prompt: {
@@ -91,7 +99,13 @@ export async function push(
     }
   }
 
-  const result = await importService.pushTranslations(config, process.cwd(), { force, verbose, prune });
+  const ignoreMatcher = createIgnoreMatcher(config.ignoreKeys ?? []);
+  const result = await importService.pushTranslations(config, process.cwd(), {
+    force,
+    verbose,
+    prune,
+    ignoreMatcher
+  });
 
   if (result.status === 'no_files') {
     consoleLog.log(chalk.yellow('No translation files found'));
@@ -113,6 +127,15 @@ export async function push(
     if (totalFiles > 0) {
       consoleLog.log(chalk.green(`✓ Found ${totalFiles} translation files`));
     }
+  }
+
+  const summary = result.ignoreSummary;
+  if (
+    verbose &&
+    summary &&
+    (summary.totalKeysIgnored > 0 || summary.zeroMatchPatterns.length > 0)
+  ) {
+    logIgnoreSummary(summary, consoleLog);
   }
 
   const { statistics } = result;

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -99,7 +99,7 @@ export async function push(
     }
   }
 
-  const ignoreMatcher = createIgnoreMatcher(config.ignoreKeys ?? []);
+  const ignoreMatcher = createIgnoreMatcher(config.translationFiles?.ignoreKeys ?? []);
   const result = await importService.pushTranslations(config, process.cwd(), {
     force,
     verbose,

--- a/src/commands/translate.ts
+++ b/src/commands/translate.ts
@@ -84,8 +84,12 @@ interface TranslationDependencies {
       targetFilesByLocale: Record<string, OriginalTranslationFile[]>,
       config: { sourceLocale: string; outputLocales: string[] },
       verbose: boolean,
-      logger?: { log: (message?: any, ...optionalParams: any[]) => void }
-    ) => Record<string, MissingLocaleEntry>;
+      logger?: { log: (message?: any, ...optionalParams: any[]) => void },
+      filterOptions?: { ignoreMatcher?: (keyName: string) => boolean }
+    ) => {
+      missing: Record<string, MissingLocaleEntry>;
+      removed: Array<{ name: string; locale?: string }>;
+    };
   };
   gitUtils: {
     autoCommitChanges: (paths: string, translationSummary?: {
@@ -205,13 +209,14 @@ export async function translate(options: TranslationOptions = {}, deps: Translat
     return;
   }
 
-  let missingByLocale = translationUtils.findMissingTranslationsByLocale(
+  const findResult = translationUtils.findMissingTranslationsByLocale(
     sourceFiles,
     targetFilesByLocale,
     config,
     !!verbose,
     console
   );
+  let missingByLocale = findResult.missing;
 
   // Capture the full manifest BEFORE filtering down to missing-only keys.
   // This is the complete snapshot of "what differs from main" for this push.

--- a/src/commands/translate.ts
+++ b/src/commands/translate.ts
@@ -17,6 +17,8 @@ import {
 } from '../utils/translation-utils.js';
 import { autoCommitChanges } from '../utils/github.js';
 import { processTranslationBatches } from '../utils/translation-processor.js';
+import { createIgnoreMatcher, summarizeRemoved } from '../utils/ignore-keys.js';
+import { logIgnoreSummary } from '../utils/ignore-keys-logging.js';
 import type {
   TranslationResult
 } from '../utils/translation-processor.js';
@@ -209,14 +211,22 @@ export async function translate(options: TranslationOptions = {}, deps: Translat
     return;
   }
 
+  const ignoreMatcher = createIgnoreMatcher(config.ignoreKeys ?? []);
+
   const findResult = translationUtils.findMissingTranslationsByLocale(
     sourceFiles,
     targetFilesByLocale,
     config,
     !!verbose,
-    console
+    console,
+    { ignoreMatcher }
   );
   let missingByLocale = findResult.missing;
+
+  const ignoreSummary = summarizeRemoved(findResult.removed, config.ignoreKeys ?? []);
+  if (verbose && (ignoreSummary.totalKeysIgnored > 0 || ignoreSummary.zeroMatchPatterns.length > 0)) {
+    logIgnoreSummary(ignoreSummary, console);
+  }
 
   // Capture the full manifest BEFORE filtering down to missing-only keys.
   // This is the complete snapshot of "what differs from main" for this push.

--- a/src/commands/translate.ts
+++ b/src/commands/translate.ts
@@ -211,7 +211,7 @@ export async function translate(options: TranslationOptions = {}, deps: Translat
     return;
   }
 
-  const ignoreMatcher = createIgnoreMatcher(config.ignoreKeys ?? []);
+  const ignoreMatcher = createIgnoreMatcher(config.translationFiles?.ignoreKeys ?? []);
 
   const findResult = translationUtils.findMissingTranslationsByLocale(
     sourceFiles,
@@ -223,7 +223,7 @@ export async function translate(options: TranslationOptions = {}, deps: Translat
   );
   let missingByLocale = findResult.missing;
 
-  const ignoreSummary = summarizeRemoved(findResult.removed, config.ignoreKeys ?? []);
+  const ignoreSummary = summarizeRemoved(findResult.removed, config.translationFiles?.ignoreKeys ?? []);
   if (verbose && (ignoreSummary.totalKeysIgnored > 0 || ignoreSummary.zeroMatchPatterns.length > 0)) {
     logIgnoreSummary(ignoreSummary, console);
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,6 +12,7 @@ export interface TranslationFileConfig {
   localeRegex?: string;
   workflow?: 'default' | 'django';
   baseBranch?: string;
+  multiLanguageFiles?: boolean;
 }
 
 // Translation file interface
@@ -23,6 +24,7 @@ export interface TranslationFile {
   namespace?: string;
   content?: string;
   hasLanguageWrapper?: boolean;
+  multiLanguage?: boolean;
   translations?: Record<string, string>;
   keys?: string[];
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -69,6 +69,9 @@ export interface ProjectConfig {
   /** Command to run after translations are updated but before commit */
   postTranslateCommand?: string;
 
+  /** Glob patterns for keys to skip entirely (client-side filter). */
+  ignoreKeys?: string[];
+
   /** Django workflow configuration */
   django?: {
     updateSources?: boolean;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,6 +13,7 @@ export interface TranslationFileConfig {
   workflow?: 'default' | 'django';
   baseBranch?: string;
   multiLanguageFiles?: boolean;
+  ignoreKeys?: string[];
 }
 
 // Translation file interface
@@ -68,9 +69,6 @@ export interface ProjectConfig {
 
   /** Command to run after translations are updated but before commit */
   postTranslateCommand?: string;
-
-  /** Glob patterns for keys to skip entirely (client-side filter). */
-  ignoreKeys?: string[];
 
   /** Django workflow configuration */
   django?: {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -154,6 +154,7 @@ export interface ImportFile {
   language: string;
   format: string;
   namespace: string;
+  multi_language?: boolean;
 }
 
 // Translation Command Dependencies

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -144,13 +144,16 @@ export const configService: ConfigService = {
       schemaVersion: DEFAULT_PROJECT_CONFIG.schemaVersion
     } as Record<string, unknown>;
 
-    const ignoreKeysValue = configWithSchema['ignoreKeys'];
-    if (
-      ignoreKeysValue === undefined ||
-      ignoreKeysValue === null ||
-      (Array.isArray(ignoreKeysValue) && ignoreKeysValue.length === 0)
-    ) {
-      delete configWithSchema['ignoreKeys'];
+    const translationFiles = configWithSchema['translationFiles'] as Record<string, unknown> | undefined;
+    if (translationFiles) {
+      const ignoreKeysValue = translationFiles['ignoreKeys'];
+      if (
+        ignoreKeysValue === undefined ||
+        ignoreKeysValue === null ||
+        (Array.isArray(ignoreKeysValue) && ignoreKeysValue.length === 0)
+      ) {
+        delete translationFiles['ignoreKeys'];
+      }
     }
 
     await fs.writeFile(configPath, JSON.stringify(configWithSchema, null, 2));
@@ -175,7 +178,7 @@ export const configService: ConfigService = {
       throw new Error('translationFiles.paths must be an array of paths');
     }
 
-    validateIgnoreKeys(config.ignoreKeys);
+    validateIgnoreKeys(config.translationFiles?.ignoreKeys);
 
     return true;
   },

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'fs';
 import path from 'path';
 import { ProjectConfig, AuthConfig } from '../types/index.js';
+import { validateIgnoreKeys } from './ignore-keys.js';
 
 /**
  * Dependencies for the config service
@@ -141,7 +142,17 @@ export const configService: ConfigService = {
       ...DEFAULT_PROJECT_CONFIG,
       ...configCopy,
       schemaVersion: DEFAULT_PROJECT_CONFIG.schemaVersion
-    };
+    } as Record<string, unknown>;
+
+    const ignoreKeysValue = configWithSchema['ignoreKeys'];
+    if (
+      ignoreKeysValue === undefined ||
+      ignoreKeysValue === null ||
+      (Array.isArray(ignoreKeysValue) && ignoreKeysValue.length === 0)
+    ) {
+      delete configWithSchema['ignoreKeys'];
+    }
+
     await fs.writeFile(configPath, JSON.stringify(configWithSchema, null, 2));
   },
 
@@ -163,6 +174,8 @@ export const configService: ConfigService = {
     if (!config.translationFiles.paths || !Array.isArray(config.translationFiles.paths)) {
       throw new Error('translationFiles.paths must be an array of paths');
     }
+
+    validateIgnoreKeys(config.ignoreKeys);
 
     return true;
   },

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -328,6 +328,7 @@ export async function findTranslationFiles(
   } = translationFiles || {};
 
   const processedFiles: TranslationFile[] = [];
+  let betaNoticeEmitted = false;
 
   // Adjustment to handle single-item braces, common mistake to use {json} instead of *.json, its not supported by glob
   const adjustPattern = (originalPattern: string): string => {
@@ -396,6 +397,10 @@ export async function findTranslationFiles(
           });
 
           if (detectMultiLanguage(parsedContent, knownLocales)) {
+            if (!betaNoticeEmitted) {
+              console.log(chalk.blue('ℹ Multi-language files: beta feature — please report issues'));
+              betaNoticeEmitted = true;
+            }
             const parsedObj = parsedContent as Record<string, unknown>;
             const base64 = Buffer.from(rawContent).toString('base64');
 

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -379,7 +379,6 @@ export async function findTranslationFiles(
 
         if (
           translationFiles?.multiLanguageFiles &&
-          parseContent &&
           (format === 'yml' || format === 'yaml' || format === 'json')
         ) {
           const fileSize = await getFileSize(filePath);

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -46,10 +46,13 @@ export function parseFile(
   }
 }
 
+const DEFAULT_LOCALE_REGEX = '(?:^|[._-])([a-z]{2}(?:-[A-Z]{2})?)\\.(?:yml|yaml|json)$';
+
 /**
  * Extract locale from file path
  */
-function extractLocaleFromPath(filePath: string, localeRegex?: string, knownLocales: string[] = []): string {
+export function extractLocaleFromPath(filePath: string, localeRegex?: string, knownLocales: string[] = []): string {
+  const effectiveLocaleRegex = localeRegex ?? DEFAULT_LOCALE_REGEX;
   if (knownLocales && knownLocales.length > 0) {
     const basenameOriginal = path.basename(filePath, path.extname(filePath));
     const isBasenameAKnownLocale = knownLocales.some(
@@ -85,16 +88,20 @@ function extractLocaleFromPath(filePath: string, localeRegex?: string, knownLoca
     return dirNameOriginal;
   }
 
-  if (localeRegex) {
-    const filenameOriginal = path.basename(filePath);
-    const regexPattern = new RegExp(localeRegex);
-    const regexMatch = filenameOriginal.match(regexPattern);
-    if (regexMatch && regexMatch[1]) {
-      const capturedLocale = regexMatch[1];
-      if (isValidLocale(capturedLocale)) {
-        return capturedLocale;
-      }
+  const filenameOriginal = path.basename(filePath);
+  const regexPattern = new RegExp(effectiveLocaleRegex);
+  const regexMatch = filenameOriginal.match(regexPattern);
+  if (regexMatch && regexMatch[1] && isValidLocale(regexMatch[1])) {
+    const capturedLocale = regexMatch[1];
+    const usingDefaultRegex = localeRegex === undefined;
+    const validKnownLocales = knownLocales.filter(Boolean);
+    if (!usingDefaultRegex || validKnownLocales.length === 0) {
+      return capturedLocale;
     }
+    const match = validKnownLocales.find(
+      (kl) => kl.toLowerCase() === capturedLocale.toLowerCase()
+    );
+    if (match) return match;
   }
 
   throw new Error(`Could not extract locale from path: ${filePath}`);
@@ -324,7 +331,7 @@ export async function findTranslationFiles(
     paths = [],
     pattern = '**/*.{json,yml,yaml,po,pot}',
     ignore = [],
-    localeRegex = '.*?([a-z]{2}(?:-[A-Z]{2})?)\\.(?:yml|yaml|json)$'
+    localeRegex = DEFAULT_LOCALE_REGEX
   } = translationFiles || {};
 
   const processedFiles: TranslationFile[] = [];

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -12,6 +12,7 @@ import type {
 } from '../types/index.js';
 import { parsePoFile, poEntriesToApiFormat } from './po-utils.js';
 import { formatFileSize, isFileTooLarge, getFileSize, FILE_SIZE_LIMITS } from './file-size.js';
+import { detectMultiLanguage } from './multi-language-detection.js';
 
 
 /**
@@ -374,6 +375,63 @@ export async function findTranslationFiles(
       try {
         const filePath = file;
         const format = path.extname(file).slice(1);
+
+        if (
+          translationFiles?.multiLanguageFiles &&
+          parseContent &&
+          (format === 'yml' || format === 'yaml' || format === 'json')
+        ) {
+          const fileSize = await getFileSize(filePath);
+          if (isFileTooLarge(fileSize)) {
+            console.error(chalk.red(
+              `✖ File too large: ${filePath} (${formatFileSize(fileSize)}) exceeds maximum size limit of ${formatFileSize(FILE_SIZE_LIMITS.MAX_SIZE)}. Skipping.`
+            ));
+            continue;
+          }
+
+          const rawContent = await readFile(filePath, 'utf8');
+          const parsedContent = parseFile(rawContent, format, filePath, {
+            sourceLanguage: sourceLocale,
+            currentLanguage: sourceLocale
+          });
+
+          if (detectMultiLanguage(parsedContent, knownLocales)) {
+            const parsedObj = parsedContent as Record<string, unknown>;
+            const base64 = Buffer.from(rawContent).toString('base64');
+
+            for (const fileLocale of Object.keys(parsedObj)) {
+              const entry: TranslationFile = {
+                path: filePath,
+                format,
+                locale: fileLocale,
+                hasLanguageWrapper: true,
+                multiLanguage: true
+              };
+              if (includeContent) {
+                entry.content = base64;
+              }
+
+              if (extractKeys) {
+                const subtree = parsedObj[fileLocale];
+                const translationData =
+                  subtree && typeof subtree === 'object' && !Array.isArray(subtree)
+                    ? (subtree as Record<string, string>)
+                    : {};
+                entry.translations = translationData;
+                const flattened = flattenTranslations(translationData, '', format);
+                // @ts-expect-error - Keep original behavior for test compatibility
+                entry.keys = flattened;
+              }
+
+              if (includeNamespace) {
+                entry.namespace = extractNamespace(filePath);
+              }
+
+              processedFiles.push(entry);
+            }
+            continue;
+          }
+        }
 
         let locale: string;
         if (format === 'pot') {

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -392,8 +392,7 @@ export async function findTranslationFiles(
 
           const rawContent = await readFile(filePath, 'utf8');
           const parsedContent = parseFile(rawContent, format, filePath, {
-            sourceLanguage: sourceLocale,
-            currentLanguage: sourceLocale
+            sourceLanguage: sourceLocale
           });
 
           if (detectMultiLanguage(parsedContent, knownLocales)) {

--- a/src/utils/ignore-keys-logging.ts
+++ b/src/utils/ignore-keys-logging.ts
@@ -1,0 +1,37 @@
+import chalk from 'chalk';
+import type { IgnoreSummary } from './ignore-keys.js';
+
+export function logIgnoreSummary(
+  summary: IgnoreSummary,
+  logger: { log: (message: string) => void }
+): void {
+  if (summary.totalKeysIgnored > 0) {
+    logger.log(
+      chalk.blue(
+        `ℹ Ignored ${summary.totalKeysIgnored} keys matching ignoreKeys patterns:`
+      )
+    );
+    for (const p of summary.perPattern) {
+      if (p.count === 0) continue;
+      const example = p.example ? ` (e.g., ${p.example})` : '';
+      logger.log(chalk.dim(`  ${p.pattern} → ${p.count} keys${example}`));
+    }
+  }
+  if (summary.totalTargetTranslationsIgnored > 0) {
+    const perLocale = Object.entries(summary.targetTranslationsPerLocale)
+      .map(([l, n]) => `${l}: ${n}`)
+      .join(', ');
+    logger.log(
+      chalk.blue(
+        `ℹ ${summary.totalTargetTranslationsIgnored} target translations for ignored keys were also filtered (${perLocale})`
+      )
+    );
+  }
+  for (const stale of summary.zeroMatchPatterns) {
+    logger.log(
+      chalk.yellow(
+        `⚠ Pattern "${stale}" in ignoreKeys matched no keys. It may be stale.`
+      )
+    );
+  }
+}

--- a/src/utils/ignore-keys.ts
+++ b/src/utils/ignore-keys.ts
@@ -66,3 +66,90 @@ export function createIgnoreMatcher(
     return prefixes.some((p) => keyName.startsWith(p));
   };
 }
+
+export function filterKeys<V>(
+  keys: Record<string, V>,
+  matcher: (keyName: string) => boolean
+): { kept: Record<string, V>; removed: string[] } {
+  const kept: Record<string, V> = {};
+  const removed: string[] = [];
+  for (const [name, value] of Object.entries(keys)) {
+    if (matcher(name)) {
+      removed.push(name);
+    } else {
+      kept[name] = value;
+    }
+  }
+  return { kept, removed };
+}
+
+export interface IgnoreSummary {
+  totalKeysIgnored: number;
+  totalTargetTranslationsIgnored: number;
+  targetTranslationsPerLocale: Record<string, number>;
+  perPattern: Array<{
+    pattern: string;
+    count: number;
+    example?: string;
+  }>;
+  zeroMatchPatterns: string[];
+}
+
+export interface RemovedKey {
+  name: string;
+  locale?: string;
+}
+
+export function summarizeRemoved(
+  removed: RemovedKey[],
+  patterns: string[]
+): IgnoreSummary {
+  const exactPatterns = new Set<string>(
+    patterns.filter((p) => !p.endsWith('.*'))
+  );
+  const prefixPatterns = patterns
+    .filter((p) => p.endsWith('.*'))
+    .map((p) => ({ pattern: p, prefix: p.slice(0, -2) + '.' }));
+
+  const counts = new Map<string, { count: number; example?: string }>();
+  for (const p of patterns) counts.set(p, { count: 0, example: undefined });
+
+  let totalTargetTranslationsIgnored = 0;
+  const targetTranslationsPerLocale: Record<string, number> = {};
+
+  for (const entry of removed) {
+    let attributed: string | undefined;
+    if (exactPatterns.has(entry.name)) {
+      attributed = entry.name;
+    } else {
+      const hit = prefixPatterns.find((pp) => entry.name.startsWith(pp.prefix));
+      if (hit) attributed = hit.pattern;
+    }
+    if (attributed) {
+      const slot = counts.get(attributed)!;
+      slot.count += 1;
+      if (slot.example === undefined) slot.example = entry.name;
+    }
+
+    if (entry.locale) {
+      totalTargetTranslationsIgnored += 1;
+      targetTranslationsPerLocale[entry.locale] =
+        (targetTranslationsPerLocale[entry.locale] ?? 0) + 1;
+    }
+  }
+
+  const perPattern = patterns.map((pattern) => {
+    const slot = counts.get(pattern)!;
+    return { pattern, count: slot.count, example: slot.example };
+  });
+  const zeroMatchPatterns = perPattern.filter((p) => p.count === 0).map((p) => p.pattern);
+  const totalKeysIgnored = perPattern.reduce((a, p) => a + p.count, 0);
+
+  return {
+    totalKeysIgnored,
+    totalTargetTranslationsIgnored,
+    targetTranslationsPerLocale,
+    perPattern,
+    zeroMatchPatterns,
+  };
+}

--- a/src/utils/ignore-keys.ts
+++ b/src/utils/ignore-keys.ts
@@ -44,3 +44,25 @@ export function validateIgnoreKeys(raw: unknown): string[] {
   }
   return result;
 }
+
+export function createIgnoreMatcher(
+  patterns: string[]
+): (keyName: string) => boolean {
+  if (patterns.length === 0) return () => false;
+
+  const exacts = new Set<string>();
+  const prefixes: string[] = [];
+
+  for (const pattern of patterns) {
+    if (pattern.endsWith('.*')) {
+      prefixes.push(pattern.slice(0, -2) + '.');
+    } else {
+      exacts.add(pattern);
+    }
+  }
+
+  return (keyName: string) => {
+    if (exacts.has(keyName)) return true;
+    return prefixes.some((p) => keyName.startsWith(p));
+  };
+}

--- a/src/utils/ignore-keys.ts
+++ b/src/utils/ignore-keys.ts
@@ -1,3 +1,5 @@
+const UNSUPPORTED_PATTERN_HINT = 'only exact matches and trailing ".*" wildcards are currently supported. Example: "activerecord.errors.*"';
+
 export function validateIgnoreKeys(raw: unknown): string[] {
   if (raw === undefined || raw === null) return [];
   if (!Array.isArray(raw)) {
@@ -5,7 +7,9 @@ export function validateIgnoreKeys(raw: unknown): string[] {
       `Invalid ignoreKeys: must be an array of strings. Got: ${typeof raw}`
     );
   }
-  raw.forEach((entry, idx) => {
+
+  const result: string[] = [];
+  for (const [idx, entry] of (raw as unknown[]).entries()) {
     if (typeof entry !== 'string') {
       throw new Error(
         `Invalid ignoreKeys: all entries must be strings. Got: ${String(entry)} at index ${idx}`
@@ -21,13 +25,13 @@ export function validateIgnoreKeys(raw: unknown): string[] {
     }
     if (entry.includes('**') || entry.includes('{') || entry.includes('}')) {
       throw new Error(
-        `Unsupported ignoreKeys pattern "${entry}": only exact matches and trailing ".*" wildcards are currently supported. Example: "activerecord.errors.*"`
+        `Unsupported ignoreKeys pattern "${entry}": ${UNSUPPORTED_PATTERN_HINT}`
       );
     }
     if (entry.includes('*')) {
       if (!entry.endsWith('.*') || entry.slice(0, -2).includes('*')) {
         throw new Error(
-          `Unsupported ignoreKeys pattern "${entry}": only exact matches and trailing ".*" wildcards are currently supported. Example: "activerecord.errors.*"`
+          `Unsupported ignoreKeys pattern "${entry}": ${UNSUPPORTED_PATTERN_HINT}`
         );
       }
     }
@@ -36,6 +40,7 @@ export function validateIgnoreKeys(raw: unknown): string[] {
         `Invalid ignoreKeys pattern "${entry}": patterns cannot end with a bare dot. Did you mean "${entry}*"?`
       );
     }
-  });
-  return raw as string[];
+    result.push(entry);
+  }
+  return result;
 }

--- a/src/utils/ignore-keys.ts
+++ b/src/utils/ignore-keys.ts
@@ -1,0 +1,41 @@
+export function validateIgnoreKeys(raw: unknown): string[] {
+  if (raw === undefined || raw === null) return [];
+  if (!Array.isArray(raw)) {
+    throw new Error(
+      `Invalid ignoreKeys: must be an array of strings. Got: ${typeof raw}`
+    );
+  }
+  raw.forEach((entry, idx) => {
+    if (typeof entry !== 'string') {
+      throw new Error(
+        `Invalid ignoreKeys: all entries must be strings. Got: ${String(entry)} at index ${idx}`
+      );
+    }
+    if (entry.length === 0) {
+      throw new Error('Invalid ignoreKeys: patterns must be non-empty.');
+    }
+    if (entry.startsWith('.')) {
+      throw new Error(
+        `Invalid ignoreKeys pattern "${entry}": patterns cannot start with a dot.`
+      );
+    }
+    if (entry.includes('**') || entry.includes('{') || entry.includes('}')) {
+      throw new Error(
+        `Unsupported ignoreKeys pattern "${entry}": only exact matches and trailing ".*" wildcards are currently supported. Example: "activerecord.errors.*"`
+      );
+    }
+    if (entry.includes('*')) {
+      if (!entry.endsWith('.*') || entry.slice(0, -2).includes('*')) {
+        throw new Error(
+          `Unsupported ignoreKeys pattern "${entry}": only exact matches and trailing ".*" wildcards are currently supported. Example: "activerecord.errors.*"`
+        );
+      }
+    }
+    if (entry.endsWith('.') && !entry.endsWith('.*')) {
+      throw new Error(
+        `Invalid ignoreKeys pattern "${entry}": patterns cannot end with a bare dot. Did you mean "${entry}*"?`
+      );
+    }
+  });
+  return raw as string[];
+}

--- a/src/utils/import-service.ts
+++ b/src/utils/import-service.ts
@@ -132,42 +132,58 @@ function readYaml(
   sourceLocale: string | undefined,
   currentLanguage: string | undefined
 ): FileReadResult {
-  try {
-    const parsed = yaml.parse(content);
-    if (!matcher) {
+  if (!matcher) {
+    try {
+      const parsed = yaml.parse(content);
       const flat = flattenTranslations(parsed);
       return {
         content: Buffer.from(content).toString('base64'),
         keys: Object.keys(flat).map((name) => ({ name, context: null })),
         removed: [],
       };
+    } catch {
+      return { content: Buffer.from(content).toString('base64'), keys: [], removed: [] };
     }
+  }
 
-    const doc = yaml.parseDocument(content);
-    const subtrees = buildSubtrees(parsed, knownLocales, sourceLocale, currentLanguage);
-    const removed: RemovedKey[] = [];
-
-    for (const { obj, pathPrefix, locale } of subtrees) {
-      const flat = flattenTranslations(obj);
-      for (const flatKey of Object.keys(flat)) {
-        if (matcher(flatKey)) {
-          doc.deleteIn([...pathPrefix, ...flatKey.split('.')]);
-          removed.push({ name: flatKey, locale });
-        }
-      }
-    }
-
-    const serialized = doc.toString();
-    const postParsed = yaml.parse(serialized);
-    const postFlat = flattenTranslations(postParsed);
-    return {
-      content: Buffer.from(serialized).toString('base64'),
-      keys: Object.keys(postFlat).map((name) => ({ name, context: null })),
-      removed,
-    };
+  let parsed: unknown;
+  let doc: yaml.Document;
+  try {
+    parsed = yaml.parse(content);
+    doc = yaml.parseDocument(content);
   } catch {
     return { content: Buffer.from(content).toString('base64'), keys: [], removed: [] };
   }
+
+  const subtrees = buildSubtrees(parsed, knownLocales, sourceLocale, currentLanguage);
+  const removed: RemovedKey[] = [];
+  const keptNames: string[] = [];
+
+  for (const { obj, pathPrefix, locale } of subtrees) {
+    const flat = flattenTranslations(obj);
+    for (const flatKey of Object.keys(flat)) {
+      const fullName = pathPrefix.length > 0 ? `${pathPrefix.join('.')}.${flatKey}` : flatKey;
+      if (matcher(flatKey)) {
+        doc.deleteIn([...pathPrefix, ...flatKey.split('.')]);
+        removed.push({ name: flatKey, locale });
+      } else {
+        keptNames.push(fullName);
+      }
+    }
+  }
+
+  let serialized: string;
+  try {
+    serialized = doc.toString();
+  } catch {
+    return { content: Buffer.from(content).toString('base64'), keys: [], removed: [] };
+  }
+
+  return {
+    content: Buffer.from(serialized).toString('base64'),
+    keys: keptNames.map((name) => ({ name, context: null })),
+    removed,
+  };
 }
 
 function readJson(
@@ -218,12 +234,17 @@ function readPo(
   options: { sourceLanguage?: string; currentLanguage?: string } | undefined,
   matcher: ((k: string) => boolean) | undefined
 ): FileReadResult {
-  if (matcher && !poWarningEmitted) {
-    console.warn(chalk.yellow('⚠ ignoreKeys does not yet support PO files; PO files will be uploaded unfiltered.'));
-    poWarningEmitted = true;
-  }
   try {
     const parsed = parsePoFile(content);
+
+    if (matcher && !poWarningEmitted) {
+      const anyMatch = parsed.entries.some((e) => e.msgid && matcher(e.msgid));
+      if (anyMatch) {
+        console.warn(chalk.yellow('⚠ ignoreKeys does not yet support PO files; PO files will be uploaded unfiltered.'));
+        poWarningEmitted = true;
+      }
+    }
+
     const apiFormat = poEntriesToApiFormat(parsed, options);
     const keys: KeyIdentifier[] = [];
     for (const entry of parsed.entries) {

--- a/src/utils/import-service.ts
+++ b/src/utils/import-service.ts
@@ -430,7 +430,7 @@ export const importService = {
       ignoreMatcher?: (keyName: string) => boolean;
     } = {}
   ): Promise<ImportResult> {
-    const ignorePatterns = config.ignoreKeys ?? [];
+    const ignorePatterns = config.translationFiles?.ignoreKeys ?? [];
     const emptySummary = summarizeRemoved([], ignorePatterns);
 
     let files = await this.findTranslationFiles(config, basePath);

--- a/src/utils/import-service.ts
+++ b/src/utils/import-service.ts
@@ -6,6 +6,8 @@ import { createImport, checkImportStatus, ImportResponse, bulkUpdateTranslations
 import { findTranslationFiles as findFiles, flattenTranslations } from './files.js';
 import { parsePoFile, poEntriesToApiFormat } from './po-utils.js';
 import { filterFilesByGitChanges } from './git-changes.js';
+import { detectMultiLanguage } from './multi-language-detection.js';
+import type { RemovedKey } from './ignore-keys.js';
 import type {
   ProjectConfig,
   TranslationFile,
@@ -51,9 +53,16 @@ export interface TranslationRecord {
   multi_language?: boolean;
 }
 
-interface FileReadResult {
+export interface FilterOptions {
+  ignoreMatcher?: (keyName: string) => boolean;
+  knownLocales?: string[];
+  sourceLocale?: string;
+}
+
+export interface FileReadResult {
   content: string;
   keys: KeyIdentifier[];
+  removed: RemovedKey[];
 }
 
 function getFileFormat(filePath: string): FileFormat {
@@ -71,80 +80,187 @@ function normalizeFormat(format: string): string {
   return format;
 }
 
-async function readFileContentWithKeys(
+let poWarningEmitted = false;
+
+export function resetPoWarning(): void {
+  poWarningEmitted = false;
+}
+
+type Subtree = {
+  obj: Record<string, unknown>;
+  pathPrefix: string[];
+  locale: string | undefined;
+};
+
+function buildSubtrees(
+  parsed: unknown,
+  knownLocales: string[],
+  sourceLocale: string | undefined,
+  currentLanguage: string | undefined
+): Subtree[] {
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return [];
+  const obj = parsed as Record<string, unknown>;
+  const topKeys = Object.keys(obj);
+
+  if (detectMultiLanguage(parsed, knownLocales)) {
+    return topKeys.map((loc) => ({
+      obj: (obj[loc] ?? {}) as Record<string, unknown>,
+      pathPrefix: [loc],
+      locale: loc === sourceLocale ? undefined : loc,
+    }));
+  }
+
+  if (topKeys.length === 1 && knownLocales.includes(topKeys[0])) {
+    const loc = topKeys[0];
+    return [
+      {
+        obj: (obj[loc] ?? {}) as Record<string, unknown>,
+        pathPrefix: [loc],
+        locale: loc === sourceLocale ? undefined : loc,
+      },
+    ];
+  }
+
+  const tag = currentLanguage && currentLanguage !== sourceLocale ? currentLanguage : undefined;
+  return [{ obj, pathPrefix: [], locale: tag }];
+}
+
+function readYaml(
+  content: string,
+  matcher: ((k: string) => boolean) | undefined,
+  knownLocales: string[],
+  sourceLocale: string | undefined,
+  currentLanguage: string | undefined
+): FileReadResult {
+  try {
+    const parsed = yaml.parse(content);
+    if (!matcher) {
+      const flat = flattenTranslations(parsed);
+      return {
+        content: Buffer.from(content).toString('base64'),
+        keys: Object.keys(flat).map((name) => ({ name, context: null })),
+        removed: [],
+      };
+    }
+
+    const doc = yaml.parseDocument(content);
+    const subtrees = buildSubtrees(parsed, knownLocales, sourceLocale, currentLanguage);
+    const removed: RemovedKey[] = [];
+
+    for (const { obj, pathPrefix, locale } of subtrees) {
+      const flat = flattenTranslations(obj);
+      for (const flatKey of Object.keys(flat)) {
+        if (matcher(flatKey)) {
+          doc.deleteIn([...pathPrefix, ...flatKey.split('.')]);
+          removed.push({ name: flatKey, locale });
+        }
+      }
+    }
+
+    const serialized = doc.toString();
+    const postParsed = yaml.parse(serialized);
+    const postFlat = flattenTranslations(postParsed);
+    return {
+      content: Buffer.from(serialized).toString('base64'),
+      keys: Object.keys(postFlat).map((name) => ({ name, context: null })),
+      removed,
+    };
+  } catch {
+    return { content: Buffer.from(content).toString('base64'), keys: [], removed: [] };
+  }
+}
+
+function readJson(
+  content: string,
+  matcher: ((k: string) => boolean) | undefined,
+  knownLocales: string[],
+  sourceLocale: string | undefined,
+  currentLanguage: string | undefined
+): FileReadResult {
+  try {
+    const parsed = JSON.parse(content);
+    if (!matcher) {
+      const flat = flattenTranslations(parsed);
+      return {
+        content: Buffer.from(JSON.stringify(flat)).toString('base64'),
+        keys: Object.keys(flat).map((name) => ({ name, context: null })),
+        removed: [],
+      };
+    }
+
+    const subtrees = buildSubtrees(parsed, knownLocales, sourceLocale, currentLanguage);
+    const removed: RemovedKey[] = [];
+    const keptFlat: Record<string, unknown> = {};
+
+    for (const { obj, pathPrefix, locale } of subtrees) {
+      const flat = flattenTranslations(obj);
+      for (const [name, value] of Object.entries(flat)) {
+        if (matcher(name)) {
+          removed.push({ name, locale });
+          continue;
+        }
+        const fullKey = pathPrefix.length > 0 ? `${pathPrefix.join('.')}.${name}` : name;
+        keptFlat[fullKey] = value;
+      }
+    }
+    return {
+      content: Buffer.from(JSON.stringify(keptFlat)).toString('base64'),
+      keys: Object.keys(keptFlat).map((name) => ({ name, context: null })),
+      removed,
+    };
+  } catch {
+    return { content: Buffer.from(content).toString('base64'), keys: [], removed: [] };
+  }
+}
+
+function readPo(
+  content: string,
+  options: { sourceLanguage?: string; currentLanguage?: string } | undefined,
+  matcher: ((k: string) => boolean) | undefined
+): FileReadResult {
+  if (matcher && !poWarningEmitted) {
+    console.warn(chalk.yellow('⚠ ignoreKeys does not yet support PO files; PO files will be uploaded unfiltered.'));
+    poWarningEmitted = true;
+  }
+  try {
+    const parsed = parsePoFile(content);
+    const apiFormat = poEntriesToApiFormat(parsed, options);
+    const keys: KeyIdentifier[] = [];
+    for (const entry of parsed.entries) {
+      if (entry.msgid) keys.push({ name: entry.msgid, context: entry.msgctxt || null });
+    }
+    return {
+      content: Buffer.from(JSON.stringify(apiFormat)).toString('base64'),
+      keys,
+      removed: [],
+    };
+  } catch {
+    return { content: Buffer.from(content).toString('base64'), keys: [], removed: [] };
+  }
+}
+
+export async function readFileContentWithKeys(
   filePath: string,
-  options?: { sourceLanguage?: string; currentLanguage?: string }
+  options?: { sourceLanguage?: string; currentLanguage?: string },
+  filterOptions?: FilterOptions
 ): Promise<FileReadResult> {
   const content = await fs.readFile(filePath, 'utf8');
   const format = getFileFormat(filePath);
-
-  if (format === 'json') {
-    try {
-      const jsonContent = JSON.parse(content);
-      const flattened = flattenTranslations(jsonContent);
-      const keys = Object.keys(flattened).map(name => ({ name, context: null }));
-
-      return {
-        content: Buffer.from(JSON.stringify(flattened)).toString('base64'),
-        keys
-      };
-    } catch {
-      return {
-        content: Buffer.from(content).toString('base64'),
-        keys: []
-      };
-    }
-  }
+  const matcher = filterOptions?.ignoreMatcher;
+  const knownLocales = filterOptions?.knownLocales ?? [];
+  const sourceLocale = filterOptions?.sourceLocale;
+  const currentLanguage = options?.currentLanguage;
 
   if (format === 'yaml') {
-    try {
-      const yamlContent = yaml.parse(content);
-      const flattened = flattenTranslations(yamlContent);
-      const keys = Object.keys(flattened).map(name => ({ name, context: null }));
-
-      return {
-        content: Buffer.from(content).toString('base64'),
-        keys
-      };
-    } catch {
-      return {
-        content: Buffer.from(content).toString('base64'),
-        keys: []
-      };
-    }
+    return readYaml(content, matcher, knownLocales, sourceLocale, currentLanguage);
   }
-
+  if (format === 'json') {
+    return readJson(content, matcher, knownLocales, sourceLocale, currentLanguage);
+  }
   if (format === 'po' || format === 'pot') {
-    try {
-      const parsed = parsePoFile(content);
-      const apiFormat = poEntriesToApiFormat(parsed, options);
-
-      const keys: KeyIdentifier[] = [];
-      for (const entry of parsed.entries) {
-        if (entry.msgid) {
-          keys.push({
-            name: entry.msgid,
-            context: entry.msgctxt || null
-          });
-        }
-      }
-
-      return {
-        content: Buffer.from(JSON.stringify(apiFormat)).toString('base64'),
-        keys
-      };
-    } catch {
-      return {
-        content: Buffer.from(content).toString('base64'),
-        keys: []
-      };
-    }
+    return readPo(content, options, matcher);
   }
-
-  return {
-    content: Buffer.from(content).toString('base64'),
-    keys: []
-  };
+  return { content: Buffer.from(content).toString('base64'), keys: [], removed: [] };
 }
 
 async function readFileContent(

--- a/src/utils/import-service.ts
+++ b/src/utils/import-service.ts
@@ -7,7 +7,8 @@ import { findTranslationFiles as findFiles, flattenTranslations } from './files.
 import { parsePoFile, poEntriesToApiFormat } from './po-utils.js';
 import { filterFilesByGitChanges } from './git-changes.js';
 import { detectMultiLanguage } from './multi-language-detection.js';
-import type { RemovedKey } from './ignore-keys.js';
+import type { IgnoreSummary, RemovedKey } from './ignore-keys.js';
+import { summarizeRemoved } from './ignore-keys.js';
 import type {
   ProjectConfig,
   TranslationFile,
@@ -37,6 +38,7 @@ export interface ImportResult {
   poll_interval?: number;
   id?: string;
   prunable_keys?: PrunableKey[];
+  ignoreSummary?: IgnoreSummary;
 }
 
 export interface KeyIdentifier {
@@ -421,12 +423,20 @@ export const importService = {
   async pushTranslations(
     config: ProjectConfig,
     basePath = process.cwd(),
-    options: { force?: boolean; verbose?: boolean; prune?: boolean } = {}
+    options: {
+      force?: boolean;
+      verbose?: boolean;
+      prune?: boolean;
+      ignoreMatcher?: (keyName: string) => boolean;
+    } = {}
   ): Promise<ImportResult> {
+    const ignorePatterns = config.ignoreKeys ?? [];
+    const emptySummary = summarizeRemoved([], ignorePatterns);
+
     let files = await this.findTranslationFiles(config, basePath);
 
     if (!files.length) {
-      return { status: 'no_files' };
+      return { status: 'no_files', ignoreSummary: emptySummary };
     }
 
     if (!options.force) {
@@ -435,7 +445,8 @@ export const importService = {
         if (filteredFiles.length === 0) {
           return {
             status: 'no_changes',
-            files: { source: [], target: [] }
+            files: { source: [], target: [] },
+            ignoreSummary: emptySummary
           };
         }
         files = filteredFiles;
@@ -448,12 +459,23 @@ export const importService = {
     const targetFiles = files.filter(file => file.language !== config.sourceLocale);
     const allTranslations: TranslationRecord[] = [];
 
+    const knownLocales = [config.sourceLocale, ...(config.outputLocales ?? [])];
+    const filterOpts: FilterOptions | undefined = options.ignoreMatcher
+      ? { ignoreMatcher: options.ignoreMatcher, knownLocales, sourceLocale: config.sourceLocale }
+      : undefined;
+    const allRemoved: RemovedKey[] = [];
+
     for (const file of sourceFiles) {
       const fullPath = path.join(basePath, file.path);
-      const fileResult = await readFileContentWithKeys(fullPath, {
-        sourceLanguage: config.sourceLocale,
-        currentLanguage: file.language
-      });
+      const fileResult = await readFileContentWithKeys(
+        fullPath,
+        {
+          sourceLanguage: config.sourceLocale,
+          currentLanguage: file.language
+        },
+        filterOpts
+      );
+      allRemoved.push(...fileResult.removed);
 
       const record: TranslationRecord = {
         language: file.language,
@@ -472,17 +494,25 @@ export const importService = {
 
     for (const file of targetFiles) {
       const fullPath = path.join(basePath, file.path);
+      const fileResult = await readFileContentWithKeys(
+        fullPath,
+        {
+          sourceLanguage: config.sourceLocale,
+          currentLanguage: file.language
+        },
+        filterOpts
+      );
       allTranslations.push({
         language: file.language,
         format: normalizeFormat(file.format),
         filename: file.path,
-        content: await readFileContent(fullPath, {
-          sourceLanguage: config.sourceLocale,
-          currentLanguage: file.language
-        }),
+        content: fileResult.content,
         multi_language: file.multi_language ?? false
       });
+      allRemoved.push(...fileResult.removed);
     }
+
+    const ignoreSummary = summarizeRemoved(allRemoved, ignorePatterns);
 
     if (options.verbose) {
       console.log(chalk.blue(`Sending ${allTranslations.length} translation files to API`));
@@ -500,7 +530,8 @@ export const importService = {
     if (importResult.import?.status === 'failed') {
       return {
         ...importResult.import,
-        files: { source: [], target: files }
+        files: { source: [], target: files },
+        ignoreSummary
       };
     }
 
@@ -513,7 +544,8 @@ export const importService = {
       if (finalImportResult.import?.status === 'failed') {
         return {
           ...finalImportResult.import,
-          files: { source: [], target: files }
+          files: { source: [], target: files },
+          ignoreSummary
         };
       }
     }
@@ -536,7 +568,8 @@ export const importService = {
       translations_url,
       sourceImport,
       files: { source: sourceFiles, target: targetFiles },
-      prunable_keys
+      prunable_keys,
+      ignoreSummary
     };
   }
 };

--- a/src/utils/import-service.ts
+++ b/src/utils/import-service.ts
@@ -48,6 +48,7 @@ export interface TranslationRecord {
   filename: string;
   content: string;
   keys?: KeyIdentifier[];
+  multi_language?: boolean;
 }
 
 interface FileReadResult {
@@ -174,7 +175,8 @@ export const importService = {
       path: path.isAbsolute(file.path) ? path.relative(basePath, file.path) : file.path,
       language: file.locale,
       format: normalizeFormat(file.format),
-      namespace: file.namespace || ''
+      namespace: file.namespace || '',
+      multi_language: file.multiLanguage ?? false
     }));
   },
 
@@ -214,7 +216,8 @@ export const importService = {
         content: await readFileContent(fullPath, {
           sourceLanguage: config.sourceLocale,
           currentLanguage: file.language
-        })
+        }),
+        multi_language: file.multi_language ?? false
       });
     }
 
@@ -227,7 +230,8 @@ export const importService = {
         content: await readFileContent(fullPath, {
           sourceLanguage: config.sourceLocale,
           currentLanguage: file.language
-        })
+        }),
+        multi_language: file.multi_language ?? false
       });
     }
 
@@ -318,7 +322,8 @@ export const importService = {
         language: file.language,
         format: normalizeFormat(file.format),
         filename: file.path,
-        content: fileResult.content
+        content: fileResult.content,
+        multi_language: file.multi_language ?? false
       };
 
       if (options.prune) {
@@ -337,7 +342,8 @@ export const importService = {
         content: await readFileContent(fullPath, {
           sourceLanguage: config.sourceLocale,
           currentLanguage: file.language
-        })
+        }),
+        multi_language: file.multi_language ?? false
       });
     }
 

--- a/src/utils/multi-language-detection.ts
+++ b/src/utils/multi-language-detection.ts
@@ -1,0 +1,17 @@
+export function detectMultiLanguage(
+  parsedContent: unknown,
+  knownLocales: string[]
+): boolean {
+  if (!parsedContent || typeof parsedContent !== 'object' || Array.isArray(parsedContent)) {
+    return false;
+  }
+  if (knownLocales.length === 0) {
+    return false;
+  }
+  const keys = Object.keys(parsedContent as Record<string, unknown>);
+  if (keys.length < 2) {
+    return false;
+  }
+  const known = new Set(knownLocales);
+  return keys.every((k) => known.has(k));
+}

--- a/src/utils/translation-updater/index.ts
+++ b/src/utils/translation-updater/index.ts
@@ -4,6 +4,7 @@ import { updateYamlFile, deleteKeysFromYamlFile } from './yaml-handler.js';
 import { updateJsonFile, deleteKeysFromJsonFile } from './json-handler.js';
 import { updatePoFile, deleteKeysFromPoFile } from './po-handler.js';
 import { isDjangoWorkflow, getDjangoSourcePath } from '../translation-utils.js';
+import { runSerializedByPath } from './path-serializer.js';
 import type { ProjectConfig, TranslationWithMetadata } from '../../types/index.js';
 
 /**
@@ -34,13 +35,15 @@ export async function updateTranslationFile(
   const actualLanguageCode = languageCode || 'en';
   const actualSourceFilePath = sourceFilePath || null;
 
-  return _updateTranslationFile(
-    filePath,
-    translations,
-    actualLanguageCode,
-    actualSourceFilePath,
-    sourceLanguage,
-    config
+  return runSerializedByPath(filePath, () =>
+    _updateTranslationFile(
+      filePath,
+      translations,
+      actualLanguageCode,
+      actualSourceFilePath,
+      sourceLanguage,
+      config
+    )
   );
 }
 

--- a/src/utils/translation-updater/json-handler.ts
+++ b/src/utils/translation-updater/json-handler.ts
@@ -33,13 +33,13 @@ function detectStructureFromContent(
     return { hasLanguageWrapper: true, jsonFormat: detectJsonFormat(innerContent) };
   }
 
-  const existingLocaleEntry = Object.entries(content).find(
+  const localeEntries = Object.entries(content).filter(
     ([key, value]) => LOCALE_KEY_REGEX.test(key) && typeof value === 'object' && value !== null
   );
-  if (existingLocaleEntry) {
+  if (localeEntries.length >= 2) {
     return {
       hasLanguageWrapper: true,
-      jsonFormat: detectJsonFormat(existingLocaleEntry[1] as Record<string, unknown>)
+      jsonFormat: detectJsonFormat(localeEntries[0][1] as Record<string, unknown>)
     };
   }
 

--- a/src/utils/translation-updater/json-handler.ts
+++ b/src/utils/translation-updater/json-handler.ts
@@ -14,6 +14,8 @@ interface FileStructure {
   jsonFormat: JsonFormat;
 }
 
+const LOCALE_KEY_REGEX = /^[a-zA-Z]{2}(-[a-zA-Z]{2})?$/;
+
 function detectStructureFromContent(
   content: Record<string, unknown>,
   languageCode: string
@@ -31,6 +33,16 @@ function detectStructureFromContent(
     return { hasLanguageWrapper: true, jsonFormat: detectJsonFormat(innerContent) };
   }
 
+  const existingLocaleEntry = Object.entries(content).find(
+    ([key, value]) => LOCALE_KEY_REGEX.test(key) && typeof value === 'object' && value !== null
+  );
+  if (existingLocaleEntry) {
+    return {
+      hasLanguageWrapper: true,
+      jsonFormat: detectJsonFormat(existingLocaleEntry[1] as Record<string, unknown>)
+    };
+  }
+
   if (Object.keys(content).length === 0) {
     return null;
   }
@@ -42,7 +54,7 @@ async function readSourceFileStructure(sourceFilePath: string): Promise<FileStru
   const sourceContent = JSON.parse(content);
 
   for (const [key, value] of Object.entries(sourceContent)) {
-    if (typeof value === 'object' && value !== null && /^[a-zA-Z]{2}(-[a-zA-Z]{2})?$/.test(key)) {
+    if (typeof value === 'object' && value !== null && LOCALE_KEY_REGEX.test(key)) {
       return {
         hasLanguageWrapper: true,
         jsonFormat: detectJsonFormat(value as Record<string, unknown>)

--- a/src/utils/translation-updater/path-serializer.ts
+++ b/src/utils/translation-updater/path-serializer.ts
@@ -1,0 +1,12 @@
+const pathQueues = new Map<string, Promise<unknown>>();
+
+export async function runSerializedByPath<T>(path: string, fn: () => Promise<T>): Promise<T> {
+  const previous = pathQueues.get(path) ?? Promise.resolve();
+  const current = previous.then(fn, fn);
+  pathQueues.set(path, current);
+  return current;
+}
+
+export function resetPathSerializer(): void {
+  pathQueues.clear();
+}

--- a/src/utils/translation-utils.ts
+++ b/src/utils/translation-utils.ts
@@ -6,6 +6,7 @@ import {
 } from '../types/index.js';
 import { TranslationBatch } from './translation-processor.js';
 import { findMissingPoTranslations, createUniqueKey, PLURAL_PREFIX } from './po-utils.js';
+import { filterKeys, RemovedKey } from './ignore-keys.js';
 
 const POT_EXTENSION = '.pot';
 
@@ -203,16 +204,23 @@ export function findMissingTranslations(
  * @param config Project configuration with sourceLocale and outputLocales
  * @param verbose Whether to show verbose output
  * @param logger Optional logger for console output
- * @returns Record of missing translations by locale and source file
+ * @param filterOptions Optional filters applied before diffing source/target keys
+ * @returns Missing translations by locale and source file, plus a list of removed keys
  */
 export function findMissingTranslationsByLocale(
   sourceFiles: TranslationFile[],
   targetFilesByLocale: Record<string, TranslationFile[]>,
   config: { sourceLocale: string; outputLocales: string[] },
   verbose: boolean,
-  logger: { log: (message?: any, ...optionalParams: any[]) => void } = console
-): Record<string, MissingLocaleEntry> {
+  logger: { log: (message?: any, ...optionalParams: any[]) => void } = console,
+  filterOptions?: { ignoreMatcher?: (keyName: string) => boolean }
+): {
+  missing: Record<string, MissingLocaleEntry>;
+  removed: RemovedKey[];
+} {
   const missingByLocale: Record<string, MissingLocaleEntry> = {};
+  const allRemoved: RemovedKey[] = [];
+  const matcher = filterOptions?.ignoreMatcher;
 
   for (const sourceFile of sourceFiles) {
     if (!sourceFile.content) continue;
@@ -228,9 +236,29 @@ export function findMissingTranslationsByLocale(
       sourceFile.format
     );
 
+    let effectiveSourceKeys = sourceKeys;
+    if (matcher) {
+      const { kept, removed } = filterKeys(sourceKeys, matcher);
+      effectiveSourceKeys = kept;
+      for (const name of removed) allRemoved.push({ name });
+    }
+
     for (const targetLocale of config.outputLocales) {
       const targetFiles = targetFilesByLocale[targetLocale] || [];
-      const result = processLocaleTranslations(sourceKeys, targetLocale, targetFiles, sourceFile, config.sourceLocale);
+      const result = processLocaleTranslations(
+        effectiveSourceKeys,
+        targetLocale,
+        targetFiles,
+        sourceFile,
+        config.sourceLocale,
+        matcher
+      );
+
+      if (result.targetRemoved && result.targetRemoved.length > 0) {
+        for (const name of result.targetRemoved) {
+          allRemoved.push({ name, locale: targetLocale });
+        }
+      }
 
       if (Object.keys(result.missingKeys).length > 0) {
         const sourceFilePath = sourceFile.path;
@@ -267,7 +295,7 @@ export function findMissingTranslationsByLocale(
     }
   }
 
-  return missingByLocale;
+  return { missing: missingByLocale, removed: allRemoved };
 }
 
 /**
@@ -529,15 +557,17 @@ export interface ProcessLocaleResult {
  * @param targetFiles Array of target translation files
  * @param sourceFile The source file
  * @param sourceLocale The source locale
- * @returns Result with target path and missing/skipped keys
+ * @param matcher Optional ignore matcher applied to target keys before diffing
+ * @returns Result with target path, missing/skipped keys, and any target keys filtered by the matcher
  */
 export function processLocaleTranslations(
   sourceKeys: Record<string, any>,
   targetLocale: string,
   targetFiles: TranslationFile[],
   sourceFile: TranslationFile,
-  sourceLocale: string
-): ProcessLocaleResult {
+  sourceLocale: string,
+  matcher?: (keyName: string) => boolean
+): ProcessLocaleResult & { targetRemoved?: string[] } {
   try {
     const targetFile = findTargetFile(targetFiles, targetLocale, sourceFile, sourceLocale);
     let targetKeys: Record<string, any> = {};
@@ -550,6 +580,13 @@ export function processLocaleTranslations(
       targetPath = targetFile.path;
     } else {
       targetPath = generateTargetPath(sourceFile, targetLocale, sourceLocale);
+    }
+
+    let targetRemoved: string[] = [];
+    if (matcher) {
+      const { kept, removed } = filterKeys(targetKeys, matcher);
+      targetKeys = kept;
+      targetRemoved = removed;
     }
 
     // Use .po-specific missing detection for .po/.pot files
@@ -612,7 +649,8 @@ export function processLocaleTranslations(
       targetPath,
       missingKeys,
       skippedKeys,
-      targetFile
+      targetFile,
+      targetRemoved
     };
   } catch (error: any) {
     throw new Error(`Failed to process translations for ${targetLocale}: ${error.message}`);

--- a/src/utils/translation-utils.ts
+++ b/src/utils/translation-utils.ts
@@ -125,6 +125,14 @@ export function findMissingTranslations(
         continue;
       }
 
+      if (details.trim() === '') {
+        skippedKeys[key] = {
+          value: details,
+          reason: 'blank_source'
+        };
+        continue;
+      }
+
       if (!targetKeys[key]) {
         missingKeys[key] = {
           value: details,
@@ -154,6 +162,18 @@ export function findMissingTranslations(
       skippedKeys[key] = {
         ...details,
         reason: 'wip'
+      };
+      continue;
+    }
+
+    if (
+      typeof details === 'object' && details !== null &&
+      typeof details.value === 'string' &&
+      details.value.trim() === ''
+    ) {
+      skippedKeys[key] = {
+        ...details,
+        reason: 'blank_source'
       };
       continue;
     }
@@ -237,7 +257,12 @@ export function findMissingTranslationsByLocale(
       }
 
       if (verbose && Object.keys(result.skippedKeys).length > 0) {
-        logger.log(`\nℹ Skipped ${Object.keys(result.skippedKeys).length} keys marked as WIP in ${sourceFile.path}`);
+        const wipCount = Object.values(result.skippedKeys).filter((d) => d.reason === 'wip').length;
+        const blankCount = Object.values(result.skippedKeys).filter((d) => d.reason === 'blank_source').length;
+        const parts: string[] = [];
+        if (wipCount > 0) parts.push(`${wipCount} marked as WIP`);
+        if (blankCount > 0) parts.push(`${blankCount} blank source placeholders`);
+        logger.log(`\nℹ Skipped ${Object.keys(result.skippedKeys).length} keys (${parts.join(', ')}) in ${sourceFile.path}`);
       }
     }
   }

--- a/tests/api/client.test.js
+++ b/tests/api/client.test.js
@@ -29,7 +29,8 @@ describe('API Client', () => {
     const mockResponse = { data: 'test' };
     global.fetch.mockResolvedValueOnce({
       ok: true,
-      json: () => Promise.resolve(mockResponse)
+      status: 200,
+      text: () => Promise.resolve(JSON.stringify(mockResponse))
     });
 
     const result = await apiRequest('/test-endpoint');
@@ -50,7 +51,8 @@ describe('API Client', () => {
     const errorMessage = 'API request failed';
     global.fetch.mockResolvedValueOnce({
       ok: false,
-      json: () => Promise.resolve({ error: { message: errorMessage } })
+      status: 400,
+      text: () => Promise.resolve(JSON.stringify({ error: { message: errorMessage } }))
     });
 
     await expect(apiRequest('/test-endpoint'))
@@ -67,7 +69,8 @@ describe('API Client', () => {
       .mockRejectedValueOnce(networkError)
       .mockResolvedValueOnce({
         ok: true,
-        json: () => Promise.resolve(mockResponse)
+        status: 200,
+        text: () => Promise.resolve(JSON.stringify(mockResponse))
       });
 
     const result = await apiRequest('/test-endpoint');
@@ -81,7 +84,7 @@ describe('API Client', () => {
     global.fetch.mockResolvedValueOnce({
       ok: false,
       status: 401,
-      json: () => Promise.resolve({ error: { code: 'invalid_api_key', message: 'Unauthorized' } })
+      text: () => Promise.resolve(JSON.stringify({ error: { code: 'invalid_api_key', message: 'Unauthorized' } }))
     });
 
     await expect(apiRequest('/test-endpoint')).rejects.toThrow('Your API key is invalid');

--- a/tests/api/client.test.ts
+++ b/tests/api/client.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
+
+describe('apiRequest', () => {
+  let apiRequest: (endpoint: string, options?: Record<string, unknown>) => Promise<unknown>;
+  let mockFetch: jest.Mock;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    mockFetch = jest.fn();
+    global.fetch = mockFetch as unknown as typeof fetch;
+    delete process.env.LOCALHERO_API_KEY;
+
+    const clientModule = await import('../../src/api/client.js');
+    apiRequest = clientModule.apiRequest;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function makeFetchResponse(opts: {
+    ok: boolean;
+    status: number;
+    body: string;
+  }) {
+    return {
+      ok: opts.ok,
+      status: opts.status,
+      text: () => Promise.resolve(opts.body),
+      headers: new Headers()
+    };
+  }
+
+  describe('HTML error responses (non-JSON bodies)', () => {
+    it('throws a friendly message for HTML 500 responses', async () => {
+      mockFetch.mockResolvedValueOnce(
+        makeFetchResponse({ ok: false, status: 500, body: '<!DOCTYPE html><html>Internal Server Error</html>' })
+      );
+
+      await expect(apiRequest('/api/v1/test')).rejects.toMatchObject({
+        message: expect.stringMatching(/Something went wrong on our end \(HTTP 500\).*hi@localhero\.ai/s)
+      });
+    });
+
+    it('throws a temporary-unavailable message for HTML 503 responses', async () => {
+      mockFetch.mockResolvedValueOnce(
+        makeFetchResponse({ ok: false, status: 503, body: '<!DOCTYPE html><html>Service Unavailable</html>' })
+      );
+
+      await expect(apiRequest('/api/v1/test')).rejects.toMatchObject({
+        message: expect.stringMatching(/temporarily unavailable.*hi@localhero\.ai/s)
+      });
+    });
+
+    it('throws a friendly message for empty-body 500 responses', async () => {
+      mockFetch.mockResolvedValueOnce(
+        makeFetchResponse({ ok: false, status: 500, body: '' })
+      );
+
+      await expect(apiRequest('/api/v1/test')).rejects.toMatchObject({
+        message: expect.stringMatching(/Something went wrong on our end \(HTTP 500\).*hi@localhero\.ai/s)
+      });
+    });
+  });
+
+  describe('valid JSON responses (regression guards)', () => {
+    it('returns parsed data for a 2xx JSON response', async () => {
+      const payload = { id: 'proj_123', name: 'My Project' };
+      mockFetch.mockResolvedValueOnce(
+        makeFetchResponse({ ok: true, status: 200, body: JSON.stringify(payload) })
+      );
+
+      const result = await apiRequest('/api/v1/test');
+
+      expect(result).toEqual(payload);
+    });
+
+    it('throws the invalid-API-key message for 401 with JSON error', async () => {
+      mockFetch.mockResolvedValueOnce(
+        makeFetchResponse({
+          ok: false,
+          status: 401,
+          body: JSON.stringify({ error: { code: 'invalid_api_key', message: 'Bad key' } })
+        })
+      );
+
+      await expect(apiRequest('/api/v1/test')).rejects.toMatchObject({
+        message: expect.stringMatching(/API key is invalid/)
+      });
+    });
+
+    it('throws a server-error message for 422 with JSON error', async () => {
+      mockFetch.mockResolvedValueOnce(
+        makeFetchResponse({
+          ok: false,
+          status: 422,
+          body: JSON.stringify({ error: { code: 'validation_failed', message: 'Invalid params' } })
+        })
+      );
+
+      await expect(apiRequest('/api/v1/test')).rejects.toMatchObject({
+        message: expect.stringMatching(/Invalid params/)
+      });
+    });
+  });
+});

--- a/tests/commands/push.test.js
+++ b/tests/commands/push.test.js
@@ -321,4 +321,109 @@ describe('push command', () => {
       }))).rejects.toThrow('API error');
     });
   });
+
+  describe('ignoreKeys', () => {
+    const emptySummary = {
+      totalKeysIgnored: 0,
+      totalTargetTranslationsIgnored: 0,
+      targetTranslationsPerLocale: {},
+      perPattern: [],
+      zeroMatchPatterns: []
+    };
+
+    it('passes an ignoreMatcher to pushTranslations when ignoreKeys is configured', async () => {
+      mockPrompt.confirm.mockResolvedValue(true);
+      mockImportService.pushTranslations.mockResolvedValue({
+        status: 'completed',
+        statistics: { updated_translations: 0, created_translations: 0 },
+        ignoreSummary: emptySummary
+      });
+
+      const configWithIgnore = { ...mockConfig, ignoreKeys: ['admin.*'] };
+      await push(configWithIgnore, { yes: true }, createPushDeps());
+
+      expect(mockImportService.pushTranslations).toHaveBeenCalledWith(
+        configWithIgnore,
+        process.cwd(),
+        expect.objectContaining({ ignoreMatcher: expect.any(Function) })
+      );
+    });
+
+    it('passes an ignoreMatcher even when ignoreKeys is absent', async () => {
+      mockPrompt.confirm.mockResolvedValue(true);
+      mockImportService.pushTranslations.mockResolvedValue({
+        status: 'completed',
+        statistics: { updated_translations: 0, created_translations: 0 },
+        ignoreSummary: emptySummary
+      });
+
+      await push(mockConfig, { yes: true }, createPushDeps());
+
+      expect(mockImportService.pushTranslations).toHaveBeenCalledWith(
+        mockConfig,
+        process.cwd(),
+        expect.objectContaining({ ignoreMatcher: expect.any(Function) })
+      );
+    });
+
+    it('does not log an ignore summary in non-verbose mode', async () => {
+      mockPrompt.confirm.mockResolvedValue(true);
+      mockImportService.pushTranslations.mockResolvedValue({
+        status: 'completed',
+        statistics: { updated_translations: 0, created_translations: 0 },
+        ignoreSummary: {
+          totalKeysIgnored: 3,
+          totalTargetTranslationsIgnored: 0,
+          targetTranslationsPerLocale: {},
+          perPattern: [{ pattern: 'admin.*', count: 3, example: 'admin.a' }],
+          zeroMatchPatterns: []
+        }
+      });
+
+      await push(mockConfig, { yes: true }, createPushDeps());
+
+      const logged = mockConsole.log.mock.calls.map(call => String(call[0]));
+      expect(logged.some(line => line.includes('Ignored'))).toBe(false);
+    });
+
+    it('logs an ignore summary in verbose mode', async () => {
+      mockPrompt.confirm.mockResolvedValue(true);
+      mockImportService.pushTranslations.mockResolvedValue({
+        status: 'completed',
+        statistics: { updated_translations: 0, created_translations: 0 },
+        ignoreSummary: {
+          totalKeysIgnored: 3,
+          totalTargetTranslationsIgnored: 0,
+          targetTranslationsPerLocale: {},
+          perPattern: [{ pattern: 'admin.*', count: 3, example: 'admin.a' }],
+          zeroMatchPatterns: []
+        }
+      });
+
+      await push(mockConfig, { yes: true, verbose: true }, createPushDeps());
+
+      const logged = mockConsole.log.mock.calls.map(call => String(call[0]));
+      expect(logged.some(line => line.includes('Ignored 3 keys'))).toBe(true);
+    });
+
+    it('logs a stale-pattern warning in verbose mode', async () => {
+      mockPrompt.confirm.mockResolvedValue(true);
+      mockImportService.pushTranslations.mockResolvedValue({
+        status: 'completed',
+        statistics: { updated_translations: 0, created_translations: 0 },
+        ignoreSummary: {
+          totalKeysIgnored: 0,
+          totalTargetTranslationsIgnored: 0,
+          targetTranslationsPerLocale: {},
+          perPattern: [{ pattern: 'obsolete.*', count: 0 }],
+          zeroMatchPatterns: ['obsolete.*']
+        }
+      });
+
+      await push(mockConfig, { yes: true, verbose: true }, createPushDeps());
+
+      const logged = mockConsole.log.mock.calls.map(call => String(call[0]));
+      expect(logged.some(line => line.includes('obsolete.*') && line.includes('stale'))).toBe(true);
+    });
+  });
 });

--- a/tests/commands/push.test.js
+++ b/tests/commands/push.test.js
@@ -339,7 +339,7 @@ describe('push command', () => {
         ignoreSummary: emptySummary
       });
 
-      const configWithIgnore = { ...mockConfig, ignoreKeys: ['admin.*'] };
+      const configWithIgnore = { ...mockConfig, translationFiles: { ...(mockConfig.translationFiles ?? {}), ignoreKeys: ['admin.*'] } };
       await push(configWithIgnore, { yes: true }, createPushDeps());
 
       const call = mockImportService.pushTranslations.mock.calls[0];

--- a/tests/commands/push.test.js
+++ b/tests/commands/push.test.js
@@ -331,7 +331,7 @@ describe('push command', () => {
       zeroMatchPatterns: []
     };
 
-    it('passes an ignoreMatcher to pushTranslations when ignoreKeys is configured', async () => {
+    it('passes an ignoreMatcher that matches configured patterns', async () => {
       mockPrompt.confirm.mockResolvedValue(true);
       mockImportService.pushTranslations.mockResolvedValue({
         status: 'completed',
@@ -342,14 +342,14 @@ describe('push command', () => {
       const configWithIgnore = { ...mockConfig, ignoreKeys: ['admin.*'] };
       await push(configWithIgnore, { yes: true }, createPushDeps());
 
-      expect(mockImportService.pushTranslations).toHaveBeenCalledWith(
-        configWithIgnore,
-        process.cwd(),
-        expect.objectContaining({ ignoreMatcher: expect.any(Function) })
-      );
+      const call = mockImportService.pushTranslations.mock.calls[0];
+      const options = call[2];
+      expect(options.ignoreMatcher).toEqual(expect.any(Function));
+      expect(options.ignoreMatcher('admin.internal')).toBe(true);
+      expect(options.ignoreMatcher('navigation.home')).toBe(false);
     });
 
-    it('passes an ignoreMatcher even when ignoreKeys is absent', async () => {
+    it('passes an always-false matcher when ignoreKeys is absent', async () => {
       mockPrompt.confirm.mockResolvedValue(true);
       mockImportService.pushTranslations.mockResolvedValue({
         status: 'completed',
@@ -359,11 +359,11 @@ describe('push command', () => {
 
       await push(mockConfig, { yes: true }, createPushDeps());
 
-      expect(mockImportService.pushTranslations).toHaveBeenCalledWith(
-        mockConfig,
-        process.cwd(),
-        expect.objectContaining({ ignoreMatcher: expect.any(Function) })
-      );
+      const call = mockImportService.pushTranslations.mock.calls[0];
+      const options = call[2];
+      expect(options.ignoreMatcher).toEqual(expect.any(Function));
+      expect(options.ignoreMatcher('anything.at.all')).toBe(false);
+      expect(options.ignoreMatcher('admin.internal')).toBe(false);
     });
 
     it('does not log an ignore summary in non-verbose mode', async () => {

--- a/tests/commands/translate.test.js
+++ b/tests/commands/translate.test.js
@@ -947,7 +947,7 @@ describe('translate command', () => {
   });
 
   describe('ignoreKeys', () => {
-    it('passes an ignoreMatcher to findMissingTranslationsByLocale', async () => {
+    it('passes an ignoreMatcher that matches configured patterns', async () => {
       configUtils.getProjectConfig.mockResolvedValue({
         projectId: 'test-project',
         sourceLocale: 'en',
@@ -972,17 +972,14 @@ describe('translate command', () => {
 
       await translate({}, createTranslateDeps());
 
-      expect(translationUtils.findMissingTranslationsByLocale).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.anything(),
-        expect.anything(),
-        expect.anything(),
-        expect.anything(),
-        expect.objectContaining({ ignoreMatcher: expect.any(Function) })
-      );
+      const call = translationUtils.findMissingTranslationsByLocale.mock.calls[0];
+      const filterOptions = call[5];
+      expect(filterOptions.ignoreMatcher).toEqual(expect.any(Function));
+      expect(filterOptions.ignoreMatcher('admin.internal')).toBe(true);
+      expect(filterOptions.ignoreMatcher('navigation.home')).toBe(false);
     });
 
-    it('passes an ignoreMatcher even when ignoreKeys is absent', async () => {
+    it('passes an always-false matcher when ignoreKeys is absent', async () => {
       fileUtils.findTranslationFiles.mockResolvedValue({
         sourceFiles: [{ path: 'locales/en.json', locale: 'en' }],
         targetFilesByLocale: { fr: [{ path: 'locales/fr.json', locale: 'fr' }] },
@@ -999,14 +996,10 @@ describe('translate command', () => {
 
       await translate({}, createTranslateDeps());
 
-      expect(translationUtils.findMissingTranslationsByLocale).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.anything(),
-        expect.anything(),
-        expect.anything(),
-        expect.anything(),
-        expect.objectContaining({ ignoreMatcher: expect.any(Function) })
-      );
+      const call = translationUtils.findMissingTranslationsByLocale.mock.calls[0];
+      const filterOptions = call[5];
+      expect(filterOptions.ignoreMatcher).toEqual(expect.any(Function));
+      expect(filterOptions.ignoreMatcher('anything')).toBe(false);
     });
 
     it('logs ignore summary in verbose mode when keys are filtered', async () => {

--- a/tests/commands/translate.test.js
+++ b/tests/commands/translate.test.js
@@ -60,7 +60,7 @@ describe('translate command', () => {
         missingKeys: { farewell: { value: 'Goodbye', sourceKey: 'farewell' } },
         skippedKeys: {}
       }),
-      findMissingTranslationsByLocale: jest.fn().mockReturnValue({}),
+      findMissingTranslationsByLocale: jest.fn().mockReturnValue({ missing: {}, removed: [] }),
       batchKeysWithMissing: jest.fn().mockReturnValue({
         batches: [],
         errors: []
@@ -98,13 +98,16 @@ describe('translate command', () => {
 
     // Configure missing translations for this test
     translationUtils.findMissingTranslationsByLocale.mockReturnValue({
-      'fr:locales/en/common.json': {
-        locale: 'fr',
-        path: sourceFilePath,
-        targetPath: targetFilePath,
-        keys: { farewell: { value: 'Goodbye', sourceKey: 'farewell' } },
-        keyCount: 1
-      }
+      missing: {
+        'fr:locales/en/common.json': {
+          locale: 'fr',
+          path: sourceFilePath,
+          targetPath: targetFilePath,
+          keys: { farewell: { value: 'Goodbye', sourceKey: 'farewell' } },
+          keyCount: 1
+        }
+      },
+      removed: []
     });
 
     // Configure batch for this test
@@ -246,20 +249,23 @@ describe('translate command', () => {
 
     // Configure missing translations for this test
     translationUtils.findMissingTranslationsByLocale.mockReturnValue({
-      'fr:locales/en/common.json': {
-        locale: 'fr',
-        path: 'locales/en/common.json',
-        targetPath: 'locales/fr/common.json',
-        keys: { farewell: { value: 'Goodbye', sourceKey: 'farewell' } },
-        keyCount: 1
+      missing: {
+        'fr:locales/en/common.json': {
+          locale: 'fr',
+          path: 'locales/en/common.json',
+          targetPath: 'locales/fr/common.json',
+          keys: { farewell: { value: 'Goodbye', sourceKey: 'farewell' } },
+          keyCount: 1
+        },
+        'fr:locales/en/home.json': {
+          locale: 'fr',
+          path: 'locales/en/home.json',
+          targetPath: 'locales/fr/home.json',
+          keys: { welcome: { value: 'Welcome', sourceKey: 'welcome' } },
+          keyCount: 1
+        }
       },
-      'fr:locales/en/home.json': {
-        locale: 'fr',
-        path: 'locales/en/home.json',
-        targetPath: 'locales/fr/home.json',
-        keys: { welcome: { value: 'Welcome', sourceKey: 'welcome' } },
-        keyCount: 1
-      }
+      removed: []
     });
 
     fileUtils.findTranslationFiles.mockResolvedValue({
@@ -460,13 +466,16 @@ describe('translate command', () => {
 
     // Configure missing translations for this test
     translationUtils.findMissingTranslationsByLocale.mockReturnValue({
-      'fr:locales/en.json': {
-        locale: 'fr',
-        path: sourceFilePath,
-        targetPath: 'locales/fr.json',
-        keys: { farewell: { value: 'Goodbye', sourceKey: 'farewell' } },
-        keyCount: 1
-      }
+      missing: {
+        'fr:locales/en.json': {
+          locale: 'fr',
+          path: sourceFilePath,
+          targetPath: 'locales/fr.json',
+          keys: { farewell: { value: 'Goodbye', sourceKey: 'farewell' } },
+          keyCount: 1
+        }
+      },
+      removed: []
     });
 
     fileUtils.findTranslationFiles.mockResolvedValue({
@@ -516,13 +525,16 @@ describe('translate command', () => {
 
     // Configure missing translations for this test
     translationUtils.findMissingTranslationsByLocale.mockReturnValue({
-      'fr:locales/en.json': {
-        locale: 'fr',
-        path: sourceFilePath,
-        targetPath: 'locales/fr.json',
-        keys: { farewell: { value: 'Goodbye', sourceKey: 'farewell' } },
-        keyCount: 1
-      }
+      missing: {
+        'fr:locales/en.json': {
+          locale: 'fr',
+          path: sourceFilePath,
+          targetPath: 'locales/fr.json',
+          keys: { farewell: { value: 'Goodbye', sourceKey: 'farewell' } },
+          keyCount: 1
+        }
+      },
+      removed: []
     });
 
     fileUtils.findTranslationFiles.mockResolvedValue({
@@ -603,13 +615,16 @@ describe('translate command', () => {
     });
 
     translationUtils.findMissingTranslationsByLocale.mockReturnValue({
-      'fr:locales/en/common.json': {
-        locale: 'fr',
-        path: sourceFilePath,
-        targetPath: 'locales/fr/common.json',
-        keys: { 'en': { value: 'en', sourceKey: 'en' } },
-        keyCount: 1
-      }
+      missing: {
+        'fr:locales/en/common.json': {
+          locale: 'fr',
+          path: sourceFilePath,
+          targetPath: 'locales/fr/common.json',
+          keys: { 'en': { value: 'en', sourceKey: 'en' } },
+          keyCount: 1
+        }
+      },
+      removed: []
     });
 
     translationUtils.batchKeysWithMissing.mockReturnValue({
@@ -679,13 +694,16 @@ describe('translate command', () => {
 
     // Configure missing translations for this test - only Norwegian has missing translations
     translationUtils.findMissingTranslationsByLocale.mockReturnValue({
-      'nb:locales/en.json': {
-        locale: 'nb',
-        path: sourceFilePath,
-        targetPath: 'locales/nb.json',
-        keys: { farewell: { value: 'Goodbye', sourceKey: 'farewell' } },
-        keyCount: 1
-      }
+      missing: {
+        'nb:locales/en.json': {
+          locale: 'nb',
+          path: sourceFilePath,
+          targetPath: 'locales/nb.json',
+          keys: { farewell: { value: 'Goodbye', sourceKey: 'farewell' } },
+          keyCount: 1
+        }
+      },
+      removed: []
     });
 
     fileUtils.findTranslationFiles.mockResolvedValue({
@@ -822,13 +840,16 @@ describe('translate command', () => {
     });
 
     translationUtils.findMissingTranslationsByLocale.mockReturnValue({
-      'fr:locales/en.json': {
-        locale: 'fr',
-        path: 'locales/en.json',
-        targetPath: 'locales/fr.json',
-        keys: { hello: { value: 'Hello', sourceKey: 'hello' } },
-        keyCount: 1
-      }
+      missing: {
+        'fr:locales/en.json': {
+          locale: 'fr',
+          path: 'locales/en.json',
+          targetPath: 'locales/fr.json',
+          keys: { hello: { value: 'Hello', sourceKey: 'hello' } },
+          keyCount: 1
+        }
+      },
+      removed: []
     });
 
     translationUtils.batchKeysWithMissing.mockReturnValue({
@@ -861,13 +882,16 @@ describe('translate command', () => {
     const targetFilePath = 'locales/fr/common.json';
 
     translationUtils.findMissingTranslationsByLocale.mockReturnValue({
-      'fr:locales/en/common.json': {
-        locale: 'fr',
-        path: sourceFilePath,
-        targetPath: targetFilePath,
-        keys: { farewell: { value: 'Goodbye', sourceKey: 'farewell' } },
-        keyCount: 1
-      }
+      missing: {
+        'fr:locales/en/common.json': {
+          locale: 'fr',
+          path: sourceFilePath,
+          targetPath: targetFilePath,
+          keys: { farewell: { value: 'Goodbye', sourceKey: 'farewell' } },
+          keyCount: 1
+        }
+      },
+      removed: []
     });
 
     translationUtils.batchKeysWithMissing.mockReturnValue({

--- a/tests/commands/translate.test.js
+++ b/tests/commands/translate.test.js
@@ -952,8 +952,7 @@ describe('translate command', () => {
         projectId: 'test-project',
         sourceLocale: 'en',
         outputLocales: ['fr'],
-        translationFiles: { paths: ['locales/'] },
-        ignoreKeys: ['admin.*']
+        translationFiles: { paths: ['locales/'], ignoreKeys: ['admin.*'] }
       });
 
       fileUtils.findTranslationFiles.mockResolvedValue({
@@ -1007,8 +1006,7 @@ describe('translate command', () => {
         projectId: 'test-project',
         sourceLocale: 'en',
         outputLocales: ['fr'],
-        translationFiles: { paths: ['locales/'] },
-        ignoreKeys: ['admin.*']
+        translationFiles: { paths: ['locales/'], ignoreKeys: ['admin.*'] }
       });
 
       fileUtils.findTranslationFiles.mockResolvedValue({
@@ -1036,8 +1034,7 @@ describe('translate command', () => {
         projectId: 'test-project',
         sourceLocale: 'en',
         outputLocales: ['fr'],
-        translationFiles: { paths: ['locales/'] },
-        ignoreKeys: ['admin.*']
+        translationFiles: { paths: ['locales/'], ignoreKeys: ['admin.*'] }
       });
 
       fileUtils.findTranslationFiles.mockResolvedValue({

--- a/tests/commands/translate.test.js
+++ b/tests/commands/translate.test.js
@@ -945,4 +945,126 @@ describe('translate command', () => {
     expect(translationUtils.updateTranslationFile).toHaveBeenCalled();
     expect(gitUtils.autoCommitChanges).not.toHaveBeenCalled();
   });
+
+  describe('ignoreKeys', () => {
+    it('passes an ignoreMatcher to findMissingTranslationsByLocale', async () => {
+      configUtils.getProjectConfig.mockResolvedValue({
+        projectId: 'test-project',
+        sourceLocale: 'en',
+        outputLocales: ['fr'],
+        translationFiles: { paths: ['locales/'] },
+        ignoreKeys: ['admin.*']
+      });
+
+      fileUtils.findTranslationFiles.mockResolvedValue({
+        sourceFiles: [{ path: 'locales/en.json', locale: 'en' }],
+        targetFilesByLocale: { fr: [{ path: 'locales/fr.json', locale: 'fr' }] },
+        allFiles: [
+          { path: 'locales/en.json', locale: 'en' },
+          { path: 'locales/fr.json', locale: 'fr' }
+        ]
+      });
+
+      translationUtils.findMissingTranslationsByLocale.mockReturnValue({
+        missing: {},
+        removed: []
+      });
+
+      await translate({}, createTranslateDeps());
+
+      expect(translationUtils.findMissingTranslationsByLocale).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ ignoreMatcher: expect.any(Function) })
+      );
+    });
+
+    it('passes an ignoreMatcher even when ignoreKeys is absent', async () => {
+      fileUtils.findTranslationFiles.mockResolvedValue({
+        sourceFiles: [{ path: 'locales/en.json', locale: 'en' }],
+        targetFilesByLocale: { fr: [{ path: 'locales/fr.json', locale: 'fr' }] },
+        allFiles: [
+          { path: 'locales/en.json', locale: 'en' },
+          { path: 'locales/fr.json', locale: 'fr' }
+        ]
+      });
+
+      translationUtils.findMissingTranslationsByLocale.mockReturnValue({
+        missing: {},
+        removed: []
+      });
+
+      await translate({}, createTranslateDeps());
+
+      expect(translationUtils.findMissingTranslationsByLocale).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ ignoreMatcher: expect.any(Function) })
+      );
+    });
+
+    it('logs ignore summary in verbose mode when keys are filtered', async () => {
+      configUtils.getProjectConfig.mockResolvedValue({
+        projectId: 'test-project',
+        sourceLocale: 'en',
+        outputLocales: ['fr'],
+        translationFiles: { paths: ['locales/'] },
+        ignoreKeys: ['admin.*']
+      });
+
+      fileUtils.findTranslationFiles.mockResolvedValue({
+        sourceFiles: [{ path: 'locales/en.json', locale: 'en' }],
+        targetFilesByLocale: { fr: [{ path: 'locales/fr.json', locale: 'fr' }] },
+        allFiles: [
+          { path: 'locales/en.json', locale: 'en' },
+          { path: 'locales/fr.json', locale: 'fr' }
+        ]
+      });
+
+      translationUtils.findMissingTranslationsByLocale.mockReturnValue({
+        missing: {},
+        removed: [{ name: 'admin.internal' }]
+      });
+
+      await translate({ verbose: true }, createTranslateDeps());
+
+      const logged = mockConsole.log.mock.calls.map(call => String(call[0]));
+      expect(logged.some(line => line.includes('Ignored 1 keys'))).toBe(true);
+    });
+
+    it('does not log ignore summary in non-verbose mode', async () => {
+      configUtils.getProjectConfig.mockResolvedValue({
+        projectId: 'test-project',
+        sourceLocale: 'en',
+        outputLocales: ['fr'],
+        translationFiles: { paths: ['locales/'] },
+        ignoreKeys: ['admin.*']
+      });
+
+      fileUtils.findTranslationFiles.mockResolvedValue({
+        sourceFiles: [{ path: 'locales/en.json', locale: 'en' }],
+        targetFilesByLocale: { fr: [{ path: 'locales/fr.json', locale: 'fr' }] },
+        allFiles: [
+          { path: 'locales/en.json', locale: 'en' },
+          { path: 'locales/fr.json', locale: 'fr' }
+        ]
+      });
+
+      translationUtils.findMissingTranslationsByLocale.mockReturnValue({
+        missing: {},
+        removed: [{ name: 'admin.internal' }]
+      });
+
+      await translate({}, createTranslateDeps());
+
+      const logged = mockConsole.log.mock.calls.map(call => String(call[0]));
+      expect(logged.some(line => line.includes('Ignored'))).toBe(false);
+    });
+  });
 });

--- a/tests/utils/config.test.js
+++ b/tests/utils/config.test.js
@@ -235,6 +235,45 @@ describe('config module', () => {
             await expect(configService.validateProjectConfig(invalidConfig))
                 .rejects.toThrow('translationFiles.paths must be an array of paths');
         });
+
+        it('rejects invalid ignoreKeys entries', async () => {
+            const invalidConfig = {
+                schemaVersion: '1.0',
+                projectId: 'x',
+                sourceLocale: 'en',
+                outputLocales: ['sv'],
+                translationFiles: { paths: ['config/locales/'] },
+                ignoreKeys: [42]
+            };
+
+            await expect(configService.validateProjectConfig(invalidConfig))
+                .rejects.toThrow(/all entries must be strings/);
+        });
+
+        it('accepts valid ignoreKeys', async () => {
+            const validConfig = {
+                schemaVersion: '1.0',
+                projectId: 'x',
+                sourceLocale: 'en',
+                outputLocales: ['sv'],
+                translationFiles: { paths: ['config/locales/'] },
+                ignoreKeys: ['activerecord.errors.*']
+            };
+
+            await expect(configService.validateProjectConfig(validConfig)).resolves.toBe(true);
+        });
+
+        it('accepts missing ignoreKeys', async () => {
+            const validConfig = {
+                schemaVersion: '1.0',
+                projectId: 'x',
+                sourceLocale: 'en',
+                outputLocales: ['sv'],
+                translationFiles: { paths: ['config/locales/'] }
+            };
+
+            await expect(configService.validateProjectConfig(validConfig)).resolves.toBe(true);
+        });
     });
 
     describe('getValidProjectConfig', () => {
@@ -302,6 +341,58 @@ describe('config module', () => {
 
             const savedConfig = JSON.parse(mockFs.writeFile.mock.calls[0][1]);
             expect(savedConfig.lastSyncedAt).toBe('2023-01-01T00:00:00.000Z');
+        });
+    });
+
+    describe('saveProjectConfig with ignoreKeys', () => {
+        it('omits ignoreKeys on save when the user did not set it', async () => {
+            const initial = {
+                schemaVersion: '1.0',
+                projectId: 'x',
+                sourceLocale: 'en',
+                outputLocales: ['sv'],
+                translationFiles: { paths: ['config/locales/'] }
+            };
+            mockFs.readFile.mockResolvedValue(JSON.stringify(initial));
+
+            await configService.updateLastSyncedAt();
+
+            const parsed = JSON.parse(mockFs.writeFile.mock.calls[0][1]);
+            expect('ignoreKeys' in parsed).toBe(false);
+        });
+
+        it('omits ignoreKeys on save when set to []', async () => {
+            const initial = {
+                schemaVersion: '1.0',
+                projectId: 'x',
+                sourceLocale: 'en',
+                outputLocales: ['sv'],
+                translationFiles: { paths: ['config/locales/'] },
+                ignoreKeys: []
+            };
+            mockFs.readFile.mockResolvedValue(JSON.stringify(initial));
+
+            await configService.updateLastSyncedAt();
+
+            const parsed = JSON.parse(mockFs.writeFile.mock.calls[0][1]);
+            expect('ignoreKeys' in parsed).toBe(false);
+        });
+
+        it('preserves ignoreKeys on save when non-empty', async () => {
+            const initial = {
+                schemaVersion: '1.0',
+                projectId: 'x',
+                sourceLocale: 'en',
+                outputLocales: ['sv'],
+                translationFiles: { paths: ['config/locales/'] },
+                ignoreKeys: ['foo.*']
+            };
+            mockFs.readFile.mockResolvedValue(JSON.stringify(initial));
+
+            await configService.updateLastSyncedAt();
+
+            const parsed = JSON.parse(mockFs.writeFile.mock.calls[0][1]);
+            expect(parsed.ignoreKeys).toEqual(['foo.*']);
         });
     });
 });

--- a/tests/utils/config.test.js
+++ b/tests/utils/config.test.js
@@ -242,8 +242,7 @@ describe('config module', () => {
                 projectId: 'x',
                 sourceLocale: 'en',
                 outputLocales: ['sv'],
-                translationFiles: { paths: ['config/locales/'] },
-                ignoreKeys: [42]
+                translationFiles: { paths: ['config/locales/'], ignoreKeys: [42] }
             };
 
             await expect(configService.validateProjectConfig(invalidConfig))
@@ -256,8 +255,7 @@ describe('config module', () => {
                 projectId: 'x',
                 sourceLocale: 'en',
                 outputLocales: ['sv'],
-                translationFiles: { paths: ['config/locales/'] },
-                ignoreKeys: ['activerecord.errors.*']
+                translationFiles: { paths: ['config/locales/'], ignoreKeys: ['activerecord.errors.*'] }
             };
 
             await expect(configService.validateProjectConfig(validConfig)).resolves.toBe(true);
@@ -358,7 +356,7 @@ describe('config module', () => {
             await configService.updateLastSyncedAt();
 
             const parsed = JSON.parse(mockFs.writeFile.mock.calls[0][1]);
-            expect('ignoreKeys' in parsed).toBe(false);
+            expect('ignoreKeys' in parsed.translationFiles).toBe(false);
         });
 
         it('omits ignoreKeys on save when set to []', async () => {
@@ -367,15 +365,14 @@ describe('config module', () => {
                 projectId: 'x',
                 sourceLocale: 'en',
                 outputLocales: ['sv'],
-                translationFiles: { paths: ['config/locales/'] },
-                ignoreKeys: []
+                translationFiles: { paths: ['config/locales/'], ignoreKeys: [] }
             };
             mockFs.readFile.mockResolvedValue(JSON.stringify(initial));
 
             await configService.updateLastSyncedAt();
 
             const parsed = JSON.parse(mockFs.writeFile.mock.calls[0][1]);
-            expect('ignoreKeys' in parsed).toBe(false);
+            expect('ignoreKeys' in parsed.translationFiles).toBe(false);
         });
 
         it('preserves ignoreKeys on save when non-empty', async () => {
@@ -384,15 +381,14 @@ describe('config module', () => {
                 projectId: 'x',
                 sourceLocale: 'en',
                 outputLocales: ['sv'],
-                translationFiles: { paths: ['config/locales/'] },
-                ignoreKeys: ['foo.*']
+                translationFiles: { paths: ['config/locales/'], ignoreKeys: ['foo.*'] }
             };
             mockFs.readFile.mockResolvedValue(JSON.stringify(initial));
 
             await configService.updateLastSyncedAt();
 
             const parsed = JSON.parse(mockFs.writeFile.mock.calls[0][1]);
-            expect(parsed.ignoreKeys).toEqual(['foo.*']);
+            expect(parsed.translationFiles.ignoreKeys).toEqual(['foo.*']);
         });
     });
 });

--- a/tests/utils/extract-locale-from-path.test.ts
+++ b/tests/utils/extract-locale-from-path.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from '@jest/globals';
+import { extractLocaleFromPath } from '../../src/utils/files.js';
+
+describe('extractLocaleFromPath', () => {
+  const knownLocales = ['en', 'sv', 'nb', 'fi'];
+  const regionalKnownLocales = ['en', 'sv', 'pt-BR', 'en-US', 'en-us'];
+
+  it('extracts locale from simple basename', () => {
+    expect(extractLocaleFromPath('config/locales/en.yml', undefined, knownLocales)).toBe('en');
+  });
+
+  it('extracts regional locale from basename (preserves case)', () => {
+    expect(extractLocaleFromPath('locales/pt-BR.yml', undefined, regionalKnownLocales)).toBe('pt-BR');
+  });
+
+  it('extracts lowercase regional locale from basename', () => {
+    expect(extractLocaleFromPath('locales/en-us.yml', undefined, regionalKnownLocales)).toBe('en-us');
+  });
+
+  it('extracts locale from dotted filename', () => {
+    expect(extractLocaleFromPath('config/locales/csv_export.en.yml', undefined, knownLocales)).toBe('en');
+  });
+
+  it('extracts regional locale from dotted filename', () => {
+    expect(extractLocaleFromPath('messages.pt-BR.yml', undefined, regionalKnownLocales)).toBe('pt-BR');
+  });
+
+  it('extracts locale from underscore-separated filename', () => {
+    expect(extractLocaleFromPath('translations_en.yml', undefined, knownLocales)).toBe('en');
+  });
+
+  it('extracts locale from dash-separated filename', () => {
+    expect(extractLocaleFromPath('translations-en.yml', undefined, knownLocales)).toBe('en');
+  });
+
+  it('extracts locale from path segment', () => {
+    expect(extractLocaleFromPath('locales/en/common.yml', undefined, knownLocales)).toBe('en');
+  });
+});
+
+describe('extractLocaleFromPath — regression guards', () => {
+  const knownLocales = ['en', 'sv', 'nb', 'fi'];
+
+  it('throws on non-locale YAML with 2-letter suffix (mailer.yml → not "er")', () => {
+    expect(() => extractLocaleFromPath('apps/messaging/config/mailer.yml', undefined, knownLocales))
+      .toThrow(/Could not extract locale from path/);
+  });
+
+  it('throws on config.yml (would greedy-match "ig")', () => {
+    expect(() => extractLocaleFromPath('some/path/config.yml', undefined, knownLocales))
+      .toThrow(/Could not extract locale from path/);
+  });
+
+  it('throws on welcome.i18n.yml (no locale suffix at all)', () => {
+    expect(() => extractLocaleFromPath('apps/views/welcome.i18n.yml', undefined, knownLocales))
+      .toThrow(/Could not extract locale from path/);
+  });
+
+  it('throws on database.yml (would greedy-match "se")', () => {
+    expect(() => extractLocaleFromPath('config/database.yml', undefined, knownLocales))
+      .toThrow(/Could not extract locale from path/);
+  });
+
+  it('throws when captured locale is NOT in knownLocales', () => {
+    // foo.da.yml looks locale-shaped, but "da" isn't configured — should throw
+    expect(() => extractLocaleFromPath('foo.da.yml', undefined, knownLocales))
+      .toThrow(/Could not extract locale from path/);
+  });
+});
+
+describe('extractLocaleFromPath — knownLocales empty', () => {
+  it('returns any valid-looking locale when knownLocales is not provided', () => {
+    expect(extractLocaleFromPath('foo.en.yml', undefined, [])).toBe('en');
+  });
+
+  it('still applies the separator-guard even when knownLocales is empty', () => {
+    // mailer.yml should throw even without a knownLocales list — separator guard does the work
+    expect(() => extractLocaleFromPath('apps/messaging/config/mailer.yml', undefined, []))
+      .toThrow(/Could not extract locale from path/);
+  });
+});
+
+describe('extractLocaleFromPath — custom regex', () => {
+  it('returns captured locale when user-supplied custom regex matches, even if not in knownLocales', () => {
+    // When the caller provides their own regex, we trust it — useful for
+    // discovering all locale files (e.g. allFiles includes unconfigured locales).
+    // The separator guard only applies to the default regex.
+    const customRegex = '(?:^|[._-])([a-z]{2}(?:-[A-Z]{2})?)\\.(?:yml|yaml|json)$';
+    expect(extractLocaleFromPath('messages.de.yml', customRegex, ['en', 'sv'])).toBe('de');
+  });
+
+  it('default regex rejects mailer.yml even without knownLocales — separator guard is sufficient', () => {
+    // Change 1 (separator guard in DEFAULT_LOCALE_REGEX) is the primary protection.
+    // "er" in "mailer" has no separator before it, so the regex never matches.
+    expect(() => extractLocaleFromPath('mailer.yml', undefined, []))
+      .toThrow(/Could not extract locale from path/);
+  });
+});

--- a/tests/utils/files-multi-language.test.ts
+++ b/tests/utils/files-multi-language.test.ts
@@ -408,4 +408,33 @@ pt-BR:
     );
     expect(noticeCalls).toHaveLength(0);
   });
+
+  it('fans out multi-language files even when parseContent is false (used by push/import-service)', async () => {
+    mockGlob.mockResolvedValue(['config/locales/invitation.i18n.yml']);
+    mockReadFile.mockResolvedValue(multiLangYaml);
+
+    const result = await findTranslationFiles({
+      sourceLocale: 'en',
+      outputLocales: ['sv', 'nb', 'fi'],
+      translationFiles: {
+        paths: ['config/locales/'],
+        multiLanguageFiles: true
+      }
+    }, {
+      parseContent: false,
+      includeContent: false,
+      extractKeys: false
+    });
+
+    const files = result as Array<{ locale: string; multiLanguage?: boolean; content?: string; translations?: unknown; keys?: unknown }>;
+    expect(files).toHaveLength(4);
+    const locales = files.map(f => f.locale).sort();
+    expect(locales).toEqual(['en', 'fi', 'nb', 'sv']);
+    files.forEach(file => {
+      expect(file.multiLanguage).toBe(true);
+      expect(file.content).toBeUndefined();
+      expect(file.translations).toBeUndefined();
+      expect(file.keys).toBeUndefined();
+    });
+  });
 });

--- a/tests/utils/files-multi-language.test.ts
+++ b/tests/utils/files-multi-language.test.ts
@@ -1,0 +1,367 @@
+import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
+
+type FindTranslationFilesFn = typeof import('../../src/utils/files.js').findTranslationFiles;
+
+describe('findTranslationFiles multi-language file fan-out', () => {
+  let findTranslationFiles: FindTranslationFilesFn;
+  let mockGlob: jest.Mock;
+  let mockReadFile: jest.Mock;
+  let originalConsole: Console;
+
+  beforeEach(async () => {
+    jest.resetModules();
+
+    mockGlob = jest.fn();
+    mockReadFile = jest.fn();
+
+    originalConsole = { ...console } as Console;
+    global.console = {
+      ...originalConsole,
+      log: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn()
+    };
+
+    await jest.unstable_mockModule('glob', () => ({
+      glob: mockGlob
+    }));
+
+    await jest.unstable_mockModule('fs/promises', () => ({
+      readFile: mockReadFile,
+      readdir: jest.fn(),
+      stat: jest.fn()
+    }));
+
+    const filesModule = await import('../../src/utils/files.js');
+    findTranslationFiles = filesModule.findTranslationFiles;
+  });
+
+  afterEach(() => {
+    global.console = originalConsole;
+  });
+
+  const multiLangYaml = `en:
+  greeting: Hello
+  nested:
+    world: World
+sv:
+  greeting: Hej
+  nested:
+    world: Världen
+nb:
+  greeting: Hei
+  nested:
+    world: Verden
+fi:
+  greeting: Moi
+  nested:
+    world: Maailma
+`;
+
+  it('fans out a multi-language YAML file into one entry per top-level locale when multiLanguageFiles is true', async () => {
+    mockGlob.mockResolvedValue(['config/locales/invitation.i18n.yml']);
+    mockReadFile.mockResolvedValue(multiLangYaml);
+
+    const result = await findTranslationFiles({
+      sourceLocale: 'en',
+      outputLocales: ['sv', 'nb', 'fi'],
+      translationFiles: {
+        paths: ['config/locales/'],
+        multiLanguageFiles: true
+      }
+    });
+
+    expect(Array.isArray(result)).toBe(true);
+    const files = result as Array<{
+      path: string;
+      locale: string;
+      format: string;
+      multiLanguage?: boolean;
+      hasLanguageWrapper?: boolean;
+      translations?: Record<string, unknown>;
+      keys?: Record<string, unknown>;
+    }>;
+
+    expect(files).toHaveLength(4);
+
+    const locales = files.map(f => f.locale).sort();
+    expect(locales).toEqual(['en', 'fi', 'nb', 'sv']);
+
+    files.forEach(file => {
+      expect(file.path).toBe('config/locales/invitation.i18n.yml');
+      expect(file.format).toBe('yml');
+      expect(file.multiLanguage).toBe(true);
+      expect(file.hasLanguageWrapper).toBe(true);
+    });
+
+    const enEntry = files.find(f => f.locale === 'en')!;
+    expect(enEntry.translations).toEqual({
+      greeting: 'Hello',
+      nested: { world: 'World' }
+    });
+    expect(enEntry.keys).toEqual({
+      greeting: 'Hello',
+      'nested.world': 'World'
+    });
+
+    const svEntry = files.find(f => f.locale === 'sv')!;
+    expect(svEntry.translations).toEqual({
+      greeting: 'Hej',
+      nested: { world: 'Världen' }
+    });
+    expect(svEntry.keys).toEqual({
+      greeting: 'Hej',
+      'nested.world': 'Världen'
+    });
+  });
+
+  it('includes multi-language fan-out entries in sourceFiles when locale matches and returnFullResult is true', async () => {
+    mockGlob.mockResolvedValue(['config/locales/invitation.i18n.yml']);
+    mockReadFile.mockResolvedValue(multiLangYaml);
+
+    const result = await findTranslationFiles({
+      sourceLocale: 'en',
+      outputLocales: ['sv', 'nb', 'fi'],
+      translationFiles: {
+        paths: ['config/locales/'],
+        multiLanguageFiles: true
+      }
+    }, {
+      returnFullResult: true
+    });
+
+    expect('allFiles' in result).toBe(true);
+    const fullResult = result as { allFiles: unknown[]; sourceFiles: unknown[]; targetFilesByLocale: Record<string, unknown[]> };
+
+    expect(fullResult.allFiles).toHaveLength(4);
+    expect(fullResult.sourceFiles).toHaveLength(1);
+    expect((fullResult.sourceFiles[0] as { locale: string }).locale).toBe('en');
+    expect(fullResult.targetFilesByLocale.sv).toHaveLength(1);
+    expect(fullResult.targetFilesByLocale.nb).toHaveLength(1);
+    expect(fullResult.targetFilesByLocale.fi).toHaveLength(1);
+  });
+
+  it('does not fan out when multiLanguageFiles flag is absent — byte-identical to today', async () => {
+    mockGlob.mockResolvedValue(['config/locales/invitation.i18n.yml']);
+    mockReadFile.mockResolvedValue(multiLangYaml);
+
+    const result = await findTranslationFiles({
+      sourceLocale: 'en',
+      outputLocales: ['sv', 'nb', 'fi'],
+      translationFiles: {
+        paths: ['config/locales/']
+      }
+    });
+
+    const files = result as Array<{ path: string; locale: string }>;
+    expect(files).toHaveLength(0);
+    expect((global.console.warn as jest.Mock)).toHaveBeenCalledWith(
+      expect.stringContaining('Could not extract locale from path'),
+      expect.any(String)
+    );
+  });
+
+  it('does not fan out when multiLanguageFiles is false — byte-identical to today', async () => {
+    mockGlob.mockResolvedValue(['config/locales/invitation.i18n.yml']);
+    mockReadFile.mockResolvedValue(multiLangYaml);
+
+    const result = await findTranslationFiles({
+      sourceLocale: 'en',
+      outputLocales: ['sv', 'nb', 'fi'],
+      translationFiles: {
+        paths: ['config/locales/'],
+        multiLanguageFiles: false
+      }
+    });
+
+    const files = result as Array<{ path: string; locale: string }>;
+    expect(files).toHaveLength(0);
+  });
+
+  it('falls through to single-lang handling when top-level keys include a non-locale', async () => {
+    mockGlob.mockResolvedValue(['config/locales/en.yml']);
+    mockReadFile.mockResolvedValue(`en:
+  greeting: Hello
+users:
+  name: Name
+`);
+
+    const result = await findTranslationFiles({
+      sourceLocale: 'en',
+      outputLocales: ['sv'],
+      translationFiles: {
+        paths: ['config/locales/'],
+        multiLanguageFiles: true
+      }
+    });
+
+    const files = result as Array<{ path: string; locale: string; hasLanguageWrapper?: boolean; multiLanguage?: boolean; translations?: Record<string, unknown> }>;
+    expect(files).toHaveLength(1);
+    expect(files[0].locale).toBe('en');
+    expect(files[0].multiLanguage).toBeUndefined();
+    expect(files[0].hasLanguageWrapper).toBe(true);
+    expect(files[0].translations).toEqual({ greeting: 'Hello' });
+  });
+
+  it('falls through to single-lang wrapper handling when only one top-level locale key is present', async () => {
+    mockGlob.mockResolvedValue(['config/locales/en.yml']);
+    mockReadFile.mockResolvedValue(`en:
+  greeting: Hello
+`);
+
+    const result = await findTranslationFiles({
+      sourceLocale: 'en',
+      outputLocales: ['sv'],
+      translationFiles: {
+        paths: ['config/locales/'],
+        multiLanguageFiles: true
+      }
+    });
+
+    const files = result as Array<{ path: string; locale: string; hasLanguageWrapper?: boolean; multiLanguage?: boolean }>;
+    expect(files).toHaveLength(1);
+    expect(files[0].locale).toBe('en');
+    expect(files[0].hasLanguageWrapper).toBe(true);
+    expect(files[0].multiLanguage).toBeUndefined();
+  });
+
+  it('falls through when top-level keys have mismatched case (case-sensitive rejection)', async () => {
+    mockGlob.mockResolvedValue(['config/locales/en.yml']);
+    mockReadFile.mockResolvedValue(`EN:
+  greeting: Hello
+SV:
+  greeting: Hej
+`);
+
+    const result = await findTranslationFiles({
+      sourceLocale: 'en',
+      outputLocales: ['sv'],
+      translationFiles: {
+        paths: ['config/locales/'],
+        multiLanguageFiles: true
+      }
+    });
+
+    const files = result as Array<{ path: string; locale: string; multiLanguage?: boolean }>;
+    expect(files).toHaveLength(1);
+    expect(files[0].locale).toBe('en');
+    expect(files[0].multiLanguage).toBeUndefined();
+  });
+
+  it('preserves case-sensitive regional locales like pt-BR verbatim in the emitted locale', async () => {
+    mockGlob.mockResolvedValue(['config/locales/invitation.i18n.yml']);
+    mockReadFile.mockResolvedValue(`en:
+  greeting: Hello
+pt-BR:
+  greeting: Olá
+`);
+
+    const result = await findTranslationFiles({
+      sourceLocale: 'en',
+      outputLocales: ['pt-BR'],
+      translationFiles: {
+        paths: ['config/locales/'],
+        multiLanguageFiles: true
+      }
+    });
+
+    const files = result as Array<{ path: string; locale: string; multiLanguage?: boolean }>;
+    expect(files).toHaveLength(2);
+    const ptBrEntry = files.find(f => f.locale === 'pt-BR');
+    expect(ptBrEntry).toBeDefined();
+    expect(ptBrEntry!.multiLanguage).toBe(true);
+  });
+
+  it('propagates parse errors via the outer try/catch so they surface as warnings — no silent fallback', async () => {
+    mockGlob.mockResolvedValue(['config/locales/invitation.i18n.yml']);
+    mockReadFile.mockResolvedValue('en:\n  greeting: "unterminated');
+
+    const result = await findTranslationFiles({
+      sourceLocale: 'en',
+      outputLocales: ['sv'],
+      translationFiles: {
+        paths: ['config/locales/'],
+        multiLanguageFiles: true
+      }
+    });
+
+    const files = result as Array<{ path: string; locale: string }>;
+    expect(files).toHaveLength(0);
+    expect((global.console.warn as jest.Mock)).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to parse')
+    );
+  });
+
+  it('handles multi-language JSON files as well', async () => {
+    mockGlob.mockResolvedValue(['config/locales/messages.i18n.json']);
+    mockReadFile.mockResolvedValue(JSON.stringify({
+      en: { greeting: 'Hello' },
+      sv: { greeting: 'Hej' }
+    }));
+
+    const result = await findTranslationFiles({
+      sourceLocale: 'en',
+      outputLocales: ['sv'],
+      translationFiles: {
+        paths: ['config/locales/'],
+        multiLanguageFiles: true
+      }
+    });
+
+    const files = result as Array<{ path: string; locale: string; format: string; multiLanguage?: boolean; translations?: Record<string, unknown> }>;
+    expect(files).toHaveLength(2);
+    files.forEach(file => {
+      expect(file.format).toBe('json');
+      expect(file.multiLanguage).toBe(true);
+    });
+    expect(files.find(f => f.locale === 'en')!.translations).toEqual({ greeting: 'Hello' });
+    expect(files.find(f => f.locale === 'sv')!.translations).toEqual({ greeting: 'Hej' });
+  });
+
+  it('emits content in base64 on each fan-out entry when includeContent is true', async () => {
+    const rawContent = multiLangYaml;
+    mockGlob.mockResolvedValue(['config/locales/invitation.i18n.yml']);
+    mockReadFile.mockResolvedValue(rawContent);
+
+    const result = await findTranslationFiles({
+      sourceLocale: 'en',
+      outputLocales: ['sv', 'nb', 'fi'],
+      translationFiles: {
+        paths: ['config/locales/'],
+        multiLanguageFiles: true
+      }
+    }, {
+      includeContent: true
+    });
+
+    const files = result as Array<{ content?: string }>;
+    const expectedBase64 = Buffer.from(rawContent).toString('base64');
+    files.forEach(file => {
+      expect(file.content).toBe(expectedBase64);
+    });
+  });
+
+  it('skips keys extraction when extractKeys is false', async () => {
+    mockGlob.mockResolvedValue(['config/locales/invitation.i18n.yml']);
+    mockReadFile.mockResolvedValue(multiLangYaml);
+
+    const result = await findTranslationFiles({
+      sourceLocale: 'en',
+      outputLocales: ['sv', 'nb', 'fi'],
+      translationFiles: {
+        paths: ['config/locales/'],
+        multiLanguageFiles: true
+      }
+    }, {
+      extractKeys: false
+    });
+
+    const files = result as Array<{ locale: string; translations?: unknown; keys?: unknown; multiLanguage?: boolean }>;
+    expect(files).toHaveLength(4);
+    files.forEach(file => {
+      expect(file.multiLanguage).toBe(true);
+      expect(file.translations).toBeUndefined();
+      expect(file.keys).toBeUndefined();
+    });
+  });
+});

--- a/tests/utils/files-multi-language.test.ts
+++ b/tests/utils/files-multi-language.test.ts
@@ -364,4 +364,48 @@ pt-BR:
       expect(file.keys).toBeUndefined();
     });
   });
+
+  it('emits the beta notice exactly once per invocation, even for multiple multi-language files', async () => {
+    mockGlob.mockResolvedValue([
+      'config/locales/one.i18n.yml',
+      'config/locales/two.i18n.yml',
+      'config/locales/three.i18n.yml'
+    ]);
+    mockReadFile.mockResolvedValue(multiLangYaml);
+
+    await findTranslationFiles({
+      sourceLocale: 'en',
+      outputLocales: ['sv', 'nb', 'fi'],
+      translationFiles: {
+        paths: ['config/locales/'],
+        multiLanguageFiles: true
+      }
+    });
+
+    const logCalls = (console.log as jest.Mock).mock.calls;
+    const noticeCalls = logCalls.filter(([msg]) =>
+      typeof msg === 'string' && msg.includes('Multi-language files: beta feature')
+    );
+    expect(noticeCalls).toHaveLength(1);
+  });
+
+  it('does not emit the beta notice when no file matches the multi-language heuristic', async () => {
+    mockGlob.mockResolvedValue(['config/locales/en.yml']);
+    mockReadFile.mockResolvedValue('hello: "Hello"\n');
+
+    await findTranslationFiles({
+      sourceLocale: 'en',
+      outputLocales: ['sv'],
+      translationFiles: {
+        paths: ['config/locales/'],
+        multiLanguageFiles: true
+      }
+    });
+
+    const logCalls = (console.log as jest.Mock).mock.calls;
+    const noticeCalls = logCalls.filter(([msg]) =>
+      typeof msg === 'string' && msg.includes('Multi-language files: beta feature')
+    );
+    expect(noticeCalls).toHaveLength(0);
+  });
 });

--- a/tests/utils/ignore-keys-logging.test.ts
+++ b/tests/utils/ignore-keys-logging.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from '@jest/globals';
+import { logIgnoreSummary } from '../../src/utils/ignore-keys-logging.js';
+import type { IgnoreSummary } from '../../src/utils/ignore-keys.js';
+
+function makeLogger() {
+  const logs: string[] = [];
+  return {
+    logger: { log: (msg: unknown) => logs.push(String(msg)) },
+    logs,
+  };
+}
+
+describe('logIgnoreSummary', () => {
+  it('emits nothing when the summary has no content', () => {
+    const summary: IgnoreSummary = {
+      totalKeysIgnored: 0,
+      totalTargetTranslationsIgnored: 0,
+      targetTranslationsPerLocale: {},
+      perPattern: [],
+      zeroMatchPatterns: [],
+    };
+    const { logger, logs } = makeLogger();
+    logIgnoreSummary(summary, logger);
+    expect(logs).toEqual([]);
+  });
+
+  it('emits the main summary line and per-pattern breakdown when keys were ignored', () => {
+    const summary: IgnoreSummary = {
+      totalKeysIgnored: 3,
+      totalTargetTranslationsIgnored: 0,
+      targetTranslationsPerLocale: {},
+      perPattern: [
+        { pattern: 'activerecord.errors.*', count: 2, example: 'activerecord.errors.foo' },
+        { pattern: 'pundit.*', count: 1, example: 'pundit.not_authorized' },
+      ],
+      zeroMatchPatterns: [],
+    };
+    const { logger, logs } = makeLogger();
+    logIgnoreSummary(summary, logger);
+    const joined = logs.join('\n');
+    expect(joined).toContain('Ignored 3 keys matching ignoreKeys patterns');
+    expect(joined).toContain('activerecord.errors.* → 2 keys (e.g., activerecord.errors.foo)');
+    expect(joined).toContain('pundit.* → 1 keys (e.g., pundit.not_authorized)');
+  });
+
+  it('skips patterns with zero count in the per-pattern output', () => {
+    const summary: IgnoreSummary = {
+      totalKeysIgnored: 1,
+      totalTargetTranslationsIgnored: 0,
+      targetTranslationsPerLocale: {},
+      perPattern: [
+        { pattern: 'foo.*', count: 1, example: 'foo.bar' },
+        { pattern: 'unused.*', count: 0, example: undefined },
+      ],
+      zeroMatchPatterns: ['unused.*'],
+    };
+    const { logger, logs } = makeLogger();
+    logIgnoreSummary(summary, logger);
+    const joined = logs.join('\n');
+    expect(joined).toContain('foo.* → 1 keys');
+    expect(joined).not.toContain('unused.* → 0 keys');
+  });
+
+  it('emits the per-locale line when target translations were filtered', () => {
+    const summary: IgnoreSummary = {
+      totalKeysIgnored: 3,
+      totalTargetTranslationsIgnored: 4,
+      targetTranslationsPerLocale: { sv: 3, nb: 1 },
+      perPattern: [{ pattern: 'foo.*', count: 3, example: 'foo.bar' }],
+      zeroMatchPatterns: [],
+    };
+    const { logger, logs } = makeLogger();
+    logIgnoreSummary(summary, logger);
+    const joined = logs.join('\n');
+    expect(joined).toContain('4 target translations for ignored keys were also filtered');
+    expect(joined).toContain('sv: 3');
+    expect(joined).toContain('nb: 1');
+  });
+
+  it('emits a stale warning for each zero-match pattern', () => {
+    const summary: IgnoreSummary = {
+      totalKeysIgnored: 0,
+      totalTargetTranslationsIgnored: 0,
+      targetTranslationsPerLocale: {},
+      perPattern: [
+        { pattern: 'stale.one.*', count: 0, example: undefined },
+        { pattern: 'stale.two', count: 0, example: undefined },
+      ],
+      zeroMatchPatterns: ['stale.one.*', 'stale.two'],
+    };
+    const { logger, logs } = makeLogger();
+    logIgnoreSummary(summary, logger);
+    const joined = logs.join('\n');
+    expect(joined).toContain('Pattern "stale.one.*" in ignoreKeys matched no keys');
+    expect(joined).toContain('Pattern "stale.two" in ignoreKeys matched no keys');
+  });
+});

--- a/tests/utils/ignore-keys.test.ts
+++ b/tests/utils/ignore-keys.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from '@jest/globals';
-import { validateIgnoreKeys } from '../../src/utils/ignore-keys.js';
+import { validateIgnoreKeys, createIgnoreMatcher } from '../../src/utils/ignore-keys.js';
 
 describe('validateIgnoreKeys', () => {
   it('returns [] when input is undefined', () => {
@@ -46,5 +46,39 @@ describe('validateIgnoreKeys', () => {
 
   it('throws on bare trailing dot', () => {
     expect(() => validateIgnoreKeys(['foo.bar.'])).toThrow(/cannot end with a bare dot.*foo\.bar\.\*/);
+  });
+});
+
+describe('createIgnoreMatcher', () => {
+  it('returns always-false when patterns is empty', () => {
+    const match = createIgnoreMatcher([]);
+    expect(match('foo')).toBe(false);
+    expect(match('foo.bar')).toBe(false);
+  });
+
+  it('matches exact patterns as literal keys', () => {
+    const match = createIgnoreMatcher(['activerecord.errors.messages.record_invalid']);
+    expect(match('activerecord.errors.messages.record_invalid')).toBe(true);
+    expect(match('activerecord.errors.messages.record_invalid.extra')).toBe(false);
+    expect(match('activerecord.errors.messages')).toBe(false);
+  });
+
+  it('matches trailing-wildcard patterns at any depth beyond the prefix', () => {
+    const match = createIgnoreMatcher(['activerecord.errors.*']);
+    expect(match('activerecord.errors.foo')).toBe(true);
+    expect(match('activerecord.errors.deep.nested.leaf')).toBe(true);
+  });
+
+  it('does NOT match the bare prefix of a trailing-wildcard pattern', () => {
+    const match = createIgnoreMatcher(['activerecord.errors.*']);
+    expect(match('activerecord.errors')).toBe(false);
+    expect(match('activerecord')).toBe(false);
+  });
+
+  it('composes multiple patterns', () => {
+    const match = createIgnoreMatcher(['activerecord.errors.*', 'pundit.*']);
+    expect(match('activerecord.errors.foo')).toBe(true);
+    expect(match('pundit.not_authorized')).toBe(true);
+    expect(match('navigation.home')).toBe(false);
   });
 });

--- a/tests/utils/ignore-keys.test.ts
+++ b/tests/utils/ignore-keys.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from '@jest/globals';
+import { validateIgnoreKeys } from '../../src/utils/ignore-keys.js';
+
+describe('validateIgnoreKeys', () => {
+  it('returns [] when input is undefined', () => {
+    expect(validateIgnoreKeys(undefined)).toEqual([]);
+  });
+
+  it('returns [] when input is null', () => {
+    expect(validateIgnoreKeys(null)).toEqual([]);
+  });
+
+  it('returns the array when all entries are valid exact or prefix patterns', () => {
+    const input = ['activerecord.errors.*', 'pundit.not_authorized'];
+    expect(validateIgnoreKeys(input)).toEqual(input);
+  });
+
+  it('throws when input is not an array', () => {
+    expect(() => validateIgnoreKeys('foo')).toThrow(/must be an array of strings/);
+  });
+
+  it('throws when an entry is not a string', () => {
+    expect(() => validateIgnoreKeys(['ok', 42 as unknown as string]))
+      .toThrow(/all entries must be strings.*at index 1/);
+  });
+
+  it('throws on empty string', () => {
+    expect(() => validateIgnoreKeys([''])).toThrow(/must be non-empty/);
+  });
+
+  it('throws on leading dot', () => {
+    expect(() => validateIgnoreKeys(['.foo.bar'])).toThrow(/cannot start with a dot/);
+  });
+
+  it('throws on mid-string wildcard', () => {
+    expect(() => validateIgnoreKeys(['foo.*.bar'])).toThrow(/only exact matches and trailing ".\*"/);
+  });
+
+  it('throws on double-star', () => {
+    expect(() => validateIgnoreKeys(['foo.**'])).toThrow(/only exact matches and trailing ".\*"/);
+  });
+
+  it('throws on brace expansion', () => {
+    expect(() => validateIgnoreKeys(['{a,b}.foo'])).toThrow(/only exact matches and trailing ".\*"/);
+  });
+
+  it('throws on bare trailing dot', () => {
+    expect(() => validateIgnoreKeys(['foo.bar.'])).toThrow(/cannot end with a bare dot.*foo\.bar\.\*/);
+  });
+});

--- a/tests/utils/ignore-keys.test.ts
+++ b/tests/utils/ignore-keys.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from '@jest/globals';
-import { validateIgnoreKeys, createIgnoreMatcher } from '../../src/utils/ignore-keys.js';
+import { validateIgnoreKeys, createIgnoreMatcher, filterKeys, summarizeRemoved } from '../../src/utils/ignore-keys.js';
 
 describe('validateIgnoreKeys', () => {
   it('returns [] when input is undefined', () => {
@@ -80,5 +80,102 @@ describe('createIgnoreMatcher', () => {
     expect(match('activerecord.errors.foo')).toBe(true);
     expect(match('pundit.not_authorized')).toBe(true);
     expect(match('navigation.home')).toBe(false);
+  });
+});
+
+describe('filterKeys', () => {
+  it('returns full kept map and empty removed when matcher is always-false', () => {
+    const matcher = (_: string) => false;
+    const input = { 'a.b': 1, 'c.d': 2 };
+    const result = filterKeys(input, matcher);
+    expect(result.kept).toEqual(input);
+    expect(result.removed).toEqual([]);
+    expect(result.kept).not.toBe(input);
+  });
+
+  it('removes matching keys and records their names', () => {
+    const matcher = createIgnoreMatcher(['activerecord.errors.*']);
+    const input = {
+      'navigation.home': 'Home',
+      'activerecord.errors.messages.foo': 'bar',
+      'activerecord.errors.models.user.email.blank': 'blank',
+    };
+    const result = filterKeys(input, matcher);
+    expect(result.kept).toEqual({ 'navigation.home': 'Home' });
+    expect(result.removed).toEqual([
+      'activerecord.errors.messages.foo',
+      'activerecord.errors.models.user.email.blank',
+    ]);
+  });
+
+  it('does not mutate input', () => {
+    const matcher = createIgnoreMatcher(['foo.*']);
+    const input = { 'foo.bar': 1, 'baz': 2 };
+    const snapshot = JSON.stringify(input);
+    filterKeys(input, matcher);
+    expect(JSON.stringify(input)).toBe(snapshot);
+  });
+
+  it('handles empty input', () => {
+    const result = filterKeys({}, createIgnoreMatcher(['foo.*']));
+    expect(result.kept).toEqual({});
+    expect(result.removed).toEqual([]);
+  });
+});
+
+describe('summarizeRemoved', () => {
+  it('returns zero summary when removed is empty, listing all patterns as stale', () => {
+    const summary = summarizeRemoved([], ['activerecord.errors.*', 'pundit.*']);
+    expect(summary.totalKeysIgnored).toBe(0);
+    expect(summary.totalTargetTranslationsIgnored).toBe(0);
+    expect(summary.targetTranslationsPerLocale).toEqual({});
+    expect(summary.perPattern.map((p) => p.pattern)).toEqual([
+      'activerecord.errors.*',
+      'pundit.*',
+    ]);
+    expect(summary.perPattern.every((p) => p.count === 0)).toBe(true);
+    expect(summary.zeroMatchPatterns).toEqual(['activerecord.errors.*', 'pundit.*']);
+  });
+
+  it('attributes counts and examples to the correct pattern', () => {
+    const summary = summarizeRemoved(
+      [
+        { name: 'activerecord.errors.foo' },
+        { name: 'activerecord.errors.bar.baz' },
+        { name: 'pundit.not_authorized' },
+      ],
+      ['activerecord.errors.*', 'pundit.*']
+    );
+    const byPattern = Object.fromEntries(summary.perPattern.map((p) => [p.pattern, p]));
+    expect(byPattern['activerecord.errors.*'].count).toBe(2);
+    expect(byPattern['activerecord.errors.*'].example).toBe('activerecord.errors.foo');
+    expect(byPattern['pundit.*'].count).toBe(1);
+    expect(byPattern['pundit.*'].example).toBe('pundit.not_authorized');
+    expect(summary.totalKeysIgnored).toBe(3);
+    expect(summary.zeroMatchPatterns).toEqual([]);
+  });
+
+  it('exact patterns win over prefix patterns', () => {
+    const summary = summarizeRemoved(
+      [{ name: 'admin.debug' }, { name: 'admin.debug.verbose' }],
+      ['admin.debug', 'admin.debug.*']
+    );
+    const byPattern = Object.fromEntries(summary.perPattern.map((p) => [p.pattern, p]));
+    expect(byPattern['admin.debug'].count).toBe(1);
+    expect(byPattern['admin.debug.*'].count).toBe(1);
+  });
+
+  it('tallies target translations per locale when locale is present', () => {
+    const summary = summarizeRemoved(
+      [
+        { name: 'activerecord.errors.foo', locale: 'sv' },
+        { name: 'activerecord.errors.bar', locale: 'nb' },
+        { name: 'activerecord.errors.baz', locale: 'sv' },
+        { name: 'activerecord.errors.qux' },
+      ],
+      ['activerecord.errors.*']
+    );
+    expect(summary.totalTargetTranslationsIgnored).toBe(3);
+    expect(summary.targetTranslationsPerLocale).toEqual({ sv: 2, nb: 1 });
   });
 });

--- a/tests/utils/ignore-keys.test.ts
+++ b/tests/utils/ignore-keys.test.ts
@@ -20,7 +20,7 @@ describe('validateIgnoreKeys', () => {
   });
 
   it('throws when an entry is not a string', () => {
-    expect(() => validateIgnoreKeys(['ok', 42 as unknown as string]))
+    expect(() => validateIgnoreKeys(['ok', 42]))
       .toThrow(/all entries must be strings.*at index 1/);
   });
 

--- a/tests/utils/import-service-multi-language.test.ts
+++ b/tests/utils/import-service-multi-language.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
+
+type PushTranslationsFn = typeof import('../../src/utils/import-service.js').importService.pushTranslations;
+type ImportTranslationsFn = typeof import('../../src/utils/import-service.js').importService.importTranslations;
+
+interface MockTranslationPayload {
+  language: string;
+  format: string;
+  filename: string;
+  content: string;
+  multi_language?: boolean;
+}
+
+interface MockBulkUpdateArgs {
+  projectId: string;
+  translations: MockTranslationPayload[];
+  includePrunable?: boolean;
+}
+
+interface MockCreateImportArgs {
+  projectId: string;
+  translations: MockTranslationPayload[];
+}
+
+describe('import-service multi_language flag threading', () => {
+  let pushTranslations: PushTranslationsFn;
+  let importTranslations: ImportTranslationsFn;
+  let mockBulkUpdate: jest.Mock;
+  let mockCreateImport: jest.Mock;
+  let mockCheckStatus: jest.Mock;
+  let mockGlob: jest.Mock;
+  let mockReadFile: jest.Mock;
+  let originalConsole: Console;
+
+  const multiLangYaml = `en:
+  greeting: Hello
+sv:
+  greeting: Hej
+nb:
+  greeting: Hei
+fi:
+  greeting: Moi
+`;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    jest.clearAllMocks();
+
+    mockGlob = jest.fn();
+    mockReadFile = jest.fn();
+    mockBulkUpdate = jest.fn();
+    mockCreateImport = jest.fn();
+    mockCheckStatus = jest.fn();
+
+    originalConsole = { ...console } as Console;
+    global.console = {
+      ...originalConsole,
+      log: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn()
+    };
+
+    await jest.unstable_mockModule('glob', () => ({
+      glob: mockGlob
+    }));
+
+    const mockStat = jest.fn().mockResolvedValue({ size: 1024 } as never);
+
+    await jest.unstable_mockModule('fs/promises', () => ({
+      readFile: mockReadFile,
+      readdir: jest.fn(),
+      stat: mockStat
+    }));
+
+    await jest.unstable_mockModule('fs', () => ({
+      promises: {
+        readFile: mockReadFile,
+        readdir: jest.fn(),
+        stat: mockStat
+      }
+    }));
+
+    await jest.unstable_mockModule('../../src/api/imports.js', () => ({
+      bulkUpdateTranslations: mockBulkUpdate,
+      createImport: mockCreateImport,
+      checkImportStatus: mockCheckStatus
+    }));
+
+    await jest.unstable_mockModule('../../src/utils/git-changes.js', () => ({
+      filterFilesByGitChanges: jest.fn().mockReturnValue(null)
+    }));
+
+    const module_ = await import('../../src/utils/import-service.js');
+    pushTranslations = module_.importService.pushTranslations.bind(module_.importService);
+    importTranslations = module_.importService.importTranslations.bind(module_.importService);
+  });
+
+  afterEach(() => {
+    global.console = originalConsole;
+    jest.restoreAllMocks();
+  });
+
+  describe('pushTranslations', () => {
+    it('sends multi_language: true on the wire for each entry of a multi-language file', async () => {
+      mockGlob.mockResolvedValue(['/fake/basepath/apps/views/mailer.i18n.yml']);
+      mockReadFile.mockResolvedValue(multiLangYaml);
+      mockBulkUpdate.mockResolvedValue({
+        import: { status: 'completed', id: 'x', poll_interval: 5 }
+      });
+
+      await pushTranslations({
+        projectId: 'test',
+        schemaVersion: '1.0',
+        sourceLocale: 'en',
+        outputLocales: ['sv', 'nb', 'fi'],
+        translationFiles: {
+          paths: ['apps/'],
+          multiLanguageFiles: true
+        },
+        lastSyncedAt: null
+      }, '/fake/basepath', { force: true, verbose: false });
+
+      expect(mockBulkUpdate).toHaveBeenCalledTimes(1);
+      const payload = mockBulkUpdate.mock.calls[0][0] as MockBulkUpdateArgs;
+      expect(payload.translations).toHaveLength(4);
+      payload.translations.forEach(t => {
+        expect(t.multi_language).toBe(true);
+      });
+      expect(payload.translations.map(t => t.language).sort()).toEqual(['en', 'fi', 'nb', 'sv']);
+    });
+
+    it('does NOT send multi_language: true for single-language files', async () => {
+      mockGlob.mockResolvedValue([
+        '/fake/basepath/config/locales/en.yml',
+        '/fake/basepath/config/locales/sv.yml'
+      ]);
+      mockReadFile.mockImplementation(async (p: unknown) => {
+        const filePath = String(p);
+        if (filePath.includes('en.yml')) return 'en:\n  greeting: Hello\n';
+        return 'sv:\n  greeting: Hej\n';
+      });
+      mockBulkUpdate.mockResolvedValue({
+        import: { status: 'completed', id: 'x', poll_interval: 5 }
+      });
+
+      await pushTranslations({
+        projectId: 'test',
+        schemaVersion: '1.0',
+        sourceLocale: 'en',
+        outputLocales: ['sv'],
+        translationFiles: {
+          paths: ['config/locales/']
+        },
+        lastSyncedAt: null
+      }, '/fake/basepath', { force: true, verbose: false });
+
+      const payload = mockBulkUpdate.mock.calls[0][0] as MockBulkUpdateArgs;
+      expect(payload.translations.length).toBeGreaterThan(0);
+      payload.translations.forEach(t => {
+        expect(t.multi_language === false || t.multi_language === undefined).toBe(true);
+      });
+    });
+  });
+
+  describe('importTranslations', () => {
+    it('sends multi_language: true on the wire for each entry of a multi-language file', async () => {
+      mockGlob.mockResolvedValue(['/fake/basepath/apps/views/mailer.i18n.yml']);
+      mockReadFile.mockResolvedValue(multiLangYaml);
+      mockCreateImport.mockResolvedValue({
+        import: { status: 'completed', id: 'x', poll_interval: 5 }
+      });
+
+      await importTranslations({
+        projectId: 'test',
+        schemaVersion: '1.0',
+        sourceLocale: 'en',
+        outputLocales: ['sv', 'nb', 'fi'],
+        translationFiles: {
+          paths: ['apps/'],
+          multiLanguageFiles: true
+        },
+        lastSyncedAt: null
+      }, '/fake/basepath');
+
+      expect(mockCreateImport).toHaveBeenCalledTimes(1);
+      const payload = mockCreateImport.mock.calls[0][0] as MockCreateImportArgs;
+      expect(payload.translations).toHaveLength(4);
+      payload.translations.forEach(t => {
+        expect(t.multi_language).toBe(true);
+      });
+      expect(payload.translations.map(t => t.language).sort()).toEqual(['en', 'fi', 'nb', 'sv']);
+    });
+
+    it('does NOT send multi_language: true for single-language files', async () => {
+      mockGlob.mockResolvedValue([
+        '/fake/basepath/config/locales/en.yml',
+        '/fake/basepath/config/locales/sv.yml'
+      ]);
+      mockReadFile.mockImplementation(async (p: unknown) => {
+        const filePath = String(p);
+        if (filePath.includes('en.yml')) return 'en:\n  greeting: Hello\n';
+        return 'sv:\n  greeting: Hej\n';
+      });
+      mockCreateImport.mockResolvedValue({
+        import: { status: 'completed', id: 'x', poll_interval: 5 }
+      });
+
+      await importTranslations({
+        projectId: 'test',
+        schemaVersion: '1.0',
+        sourceLocale: 'en',
+        outputLocales: ['sv'],
+        translationFiles: {
+          paths: ['config/locales/']
+        },
+        lastSyncedAt: null
+      }, '/fake/basepath');
+
+      const payload = mockCreateImport.mock.calls[0][0] as MockCreateImportArgs;
+      expect(payload.translations.length).toBeGreaterThan(0);
+      payload.translations.forEach(t => {
+        expect(t.multi_language === false || t.multi_language === undefined).toBe(true);
+      });
+    });
+  });
+});

--- a/tests/utils/import-service.push.test.ts
+++ b/tests/utils/import-service.push.test.ts
@@ -80,8 +80,7 @@ describe('pushTranslations with ignoreMatcher', () => {
         projectId: 'test',
         sourceLocale: 'en',
         outputLocales: ['sv'],
-        translationFiles: { paths: ['.'] },
-        ignoreKeys: ['activerecord.errors.*'],
+        translationFiles: { paths: ['.'], ignoreKeys: ['activerecord.errors.*'] },
         lastSyncedAt: null
       },
       tmp,

--- a/tests/utils/import-service.push.test.ts
+++ b/tests/utils/import-service.push.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
+import { promises as fs } from 'fs';
+import path from 'path';
+import os from 'os';
+
+interface MockTranslationPayload {
+  language: string;
+  format: string;
+  filename: string;
+  content: string;
+  multi_language?: boolean;
+}
+
+interface MockBulkUpdateArgs {
+  projectId: string;
+  translations: MockTranslationPayload[];
+  includePrunable?: boolean;
+}
+
+describe('pushTranslations with ignoreMatcher', () => {
+  let tmp: string;
+  let mockBulkUpdate: jest.Mock;
+  let mockCreateImport: jest.Mock;
+  let mockCheckStatus: jest.Mock;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    jest.clearAllMocks();
+
+    tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'pushtest-'));
+
+    mockBulkUpdate = jest.fn();
+    mockCreateImport = jest.fn();
+    mockCheckStatus = jest.fn();
+
+    await jest.unstable_mockModule('../../src/api/imports.js', () => ({
+      bulkUpdateTranslations: mockBulkUpdate,
+      createImport: mockCreateImport,
+      checkImportStatus: mockCheckStatus
+    }));
+
+    await jest.unstable_mockModule('../../src/utils/git-changes.js', () => ({
+      filterFilesByGitChanges: jest.fn().mockReturnValue(null)
+    }));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmp, { recursive: true, force: true });
+    jest.restoreAllMocks();
+  });
+
+  it('filters matched keys from uploaded source content and populates ignoreSummary', async () => {
+    mockBulkUpdate.mockResolvedValue({
+      import: {
+        status: 'completed',
+        id: 'test-import',
+        statistics: { created_translations: 0, updated_translations: 0 }
+      }
+    });
+
+    await fs.writeFile(
+      path.join(tmp, 'en.yml'),
+      'en:\n  navigation:\n    home: "Home"\n  activerecord:\n    errors:\n      foo: "bar"\n',
+      'utf8'
+    );
+    await fs.writeFile(
+      path.join(tmp, 'sv.yml'),
+      'sv:\n  navigation:\n    home: "Hem"\n',
+      'utf8'
+    );
+
+    const { importService, resetPoWarning } = await import('../../src/utils/import-service.js');
+    const { createIgnoreMatcher } = await import('../../src/utils/ignore-keys.js');
+    resetPoWarning();
+
+    const matcher = createIgnoreMatcher(['activerecord.errors.*']);
+    const result = await importService.pushTranslations(
+      {
+        schemaVersion: '1.0',
+        projectId: 'test',
+        sourceLocale: 'en',
+        outputLocales: ['sv'],
+        translationFiles: { paths: ['.'] },
+        ignoreKeys: ['activerecord.errors.*'],
+        lastSyncedAt: null
+      },
+      tmp,
+      { force: true, ignoreMatcher: matcher }
+    );
+
+    expect(result.ignoreSummary).toBeDefined();
+    expect(result.ignoreSummary?.totalKeysIgnored).toBe(1);
+
+    expect(mockBulkUpdate).toHaveBeenCalledTimes(1);
+    const call = mockBulkUpdate.mock.calls[0]?.[0] as MockBulkUpdateArgs;
+    expect(call).toBeDefined();
+    const sourceRecord = call.translations.find((t) => t.language === 'en');
+    expect(sourceRecord).toBeDefined();
+    const decoded = Buffer.from(sourceRecord!.content, 'base64').toString();
+    expect(decoded).not.toMatch(/foo:\s*"bar"/);
+    expect(decoded).toContain('navigation');
+    expect(decoded).toContain('home: "Home"');
+  });
+});

--- a/tests/utils/import-service.test.js
+++ b/tests/utils/import-service.test.js
@@ -153,9 +153,9 @@ describe('importService', () => {
       );
 
       expect(result).toEqual([
-        { path: 'locales/en.json', language: 'en', format: 'json', namespace: '' },
-        { path: 'locales/fr.yml', language: 'fr', format: 'yaml', namespace: '' },
-        { path: 'locales/es.yaml', language: 'es', format: 'yaml', namespace: '' }
+        { path: 'locales/en.json', language: 'en', format: 'json', namespace: '', multi_language: false },
+        { path: 'locales/fr.yml', language: 'fr', format: 'yaml', namespace: '', multi_language: false },
+        { path: 'locales/es.yaml', language: 'es', format: 'yaml', namespace: '', multi_language: false }
       ]);
     });
 
@@ -213,8 +213,8 @@ describe('importService', () => {
 
       expect(result.status).toBe('completed');
       expect(result.files).toEqual({
-        source: [{ path: 'locales/en.json', language: 'en', format: 'json', namespace: '' }],
-        target: [{ path: 'locales/fr.json', language: 'fr', format: 'json', namespace: '' }]
+        source: [{ path: 'locales/en.json', language: 'en', format: 'json', namespace: '', multi_language: false }],
+        target: [{ path: 'locales/fr.json', language: 'fr', format: 'json', namespace: '', multi_language: false }]
       });
 
       expect(mockImportsApi.createImport).toHaveBeenCalledWith({
@@ -224,13 +224,15 @@ describe('importService', () => {
             filename: 'locales/en.json',
             language: 'en',
             format: 'json',
-            content: 'eyJoZWxsbyI6IkhlbGxvIn0='
+            content: 'eyJoZWxsbyI6IkhlbGxvIn0=',
+            multi_language: false
           },
           {
             filename: 'locales/fr.json',
             language: 'fr',
             format: 'json',
-            content: 'eyJoZWxsbyI6IkJvbmpvdXIifQ=='
+            content: 'eyJoZWxsbyI6IkJvbmpvdXIifQ==',
+            multi_language: false
           }
         ]
       });
@@ -303,7 +305,8 @@ describe('importService', () => {
             filename: 'locales/en.json',
             language: 'en',
             format: 'json',
-            content: 'eyJoZWxsbyI6IkhlbGxvIn0='
+            content: 'eyJoZWxsbyI6IkhlbGxvIn0=',
+            multi_language: false
           }
         ]
       });

--- a/tests/utils/import-service.test.ts
+++ b/tests/utils/import-service.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { promises as fs } from 'fs';
+import path from 'path';
+import os from 'os';
+import {
+  readFileContentWithKeys,
+  resetPoWarning,
+} from '../../src/utils/import-service.js';
+import { createIgnoreMatcher } from '../../src/utils/ignore-keys.js';
+
+const knownLocales = ['en', 'sv', 'nb', 'fi'];
+
+describe('readFileContentWithKeys with ignoreMatcher', () => {
+  let tmp: string;
+  beforeEach(async () => {
+    tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'ignorekeys-'));
+    resetPoWarning();
+  });
+  afterEach(async () => {
+    await fs.rm(tmp, { recursive: true, force: true });
+  });
+
+  it('removes matching keys from wrapped single-lang YAML and preserves surrounding formatting', async () => {
+    const src = [
+      'en:',
+      '  navigation:',
+      '    home: "Home"',
+      '  activerecord:',
+      '    errors:',
+      '      messages:',
+      '        foo: "bar"',
+      '',
+    ].join('\n');
+    const p = path.join(tmp, 'en.yml');
+    await fs.writeFile(p, src, 'utf8');
+    const matcher = createIgnoreMatcher(['activerecord.errors.*']);
+    const out = await readFileContentWithKeys(
+      p,
+      { sourceLanguage: 'en', currentLanguage: 'en' },
+      { ignoreMatcher: matcher, knownLocales, sourceLocale: 'en' }
+    );
+    const decoded = Buffer.from(out.content, 'base64').toString();
+    expect(decoded).not.toMatch(/foo:/);
+    expect(decoded).toContain('home: "Home"');
+    const keyNames = out.keys.map((k) => k.name);
+    expect(keyNames.length).toBe(1);
+    expect(keyNames[0]).toMatch(/navigation\.home$/);
+    expect(out.removed).toEqual([{ name: 'activerecord.errors.messages.foo', locale: undefined }]);
+  });
+
+  it('removes matching keys from wrapped single-lang TARGET YAML and tags removals with the file locale', async () => {
+    const src = [
+      'sv:',
+      '  navigation:',
+      '    home: "Hem"',
+      '  activerecord:',
+      '    errors:',
+      '      foo: "bar"',
+      '',
+    ].join('\n');
+    const p = path.join(tmp, 'sv.yml');
+    await fs.writeFile(p, src, 'utf8');
+    const matcher = createIgnoreMatcher(['activerecord.errors.*']);
+    const out = await readFileContentWithKeys(
+      p,
+      { sourceLanguage: 'en', currentLanguage: 'sv' },
+      { ignoreMatcher: matcher, knownLocales, sourceLocale: 'en' }
+    );
+    expect(out.removed).toEqual([{ name: 'activerecord.errors.foo', locale: 'sv' }]);
+  });
+
+  it('removes matching keys from multi-lang YAML across all locale wrappers', async () => {
+    const src = [
+      '---',
+      'en:',
+      '  navigation:',
+      '    home: "Home"',
+      '  activerecord:',
+      '    errors:',
+      '      foo: "bar"',
+      'sv:',
+      '  navigation:',
+      '    home: "Hem"',
+      '  activerecord:',
+      '    errors:',
+      '      foo: "bar"',
+      '',
+    ].join('\n');
+    const p = path.join(tmp, 'multilang.i18n.yml');
+    await fs.writeFile(p, src, 'utf8');
+    const matcher = createIgnoreMatcher(['activerecord.errors.*']);
+    const out = await readFileContentWithKeys(
+      p,
+      { sourceLanguage: 'en', currentLanguage: 'en' },
+      { ignoreMatcher: matcher, knownLocales, sourceLocale: 'en' }
+    );
+    const decoded = Buffer.from(out.content, 'base64').toString();
+    expect(decoded).not.toMatch(/foo:/);
+    expect(decoded).toContain('home: "Home"');
+    expect(decoded).toContain('home: "Hem"');
+    const names = out.removed.map((r) => r.name);
+    expect(names.every((n) => n === 'activerecord.errors.foo')).toBe(true);
+    const locales = new Set(out.removed.map((r) => r.locale));
+    expect(locales).toEqual(new Set([undefined, 'sv']));
+  });
+
+  it('filters JSON by deleting from flattened object', async () => {
+    const src = JSON.stringify({
+      navigation: { home: 'Home' },
+      activerecord: { errors: { foo: 'bar' } },
+    });
+    const p = path.join(tmp, 'en.json');
+    await fs.writeFile(p, src, 'utf8');
+    const matcher = createIgnoreMatcher(['activerecord.errors.*']);
+    const out = await readFileContentWithKeys(
+      p,
+      { sourceLanguage: 'en', currentLanguage: 'en' },
+      { ignoreMatcher: matcher, knownLocales, sourceLocale: 'en' }
+    );
+    const decoded = Buffer.from(out.content, 'base64').toString();
+    const parsed = JSON.parse(decoded);
+    expect(parsed['activerecord.errors.foo']).toBeUndefined();
+    expect(parsed['navigation.home']).toBe('Home');
+    expect(out.removed[0]?.name).toBe('activerecord.errors.foo');
+  });
+
+  it('skips PO files with a one-shot warning per process', async () => {
+    const src = 'msgid "foo"\nmsgstr "bar"\n';
+    const p1 = path.join(tmp, 'a.po');
+    const p2 = path.join(tmp, 'b.po');
+    await fs.writeFile(p1, src, 'utf8');
+    await fs.writeFile(p2, src, 'utf8');
+    const matcher = createIgnoreMatcher(['foo']);
+    const warnings: string[] = [];
+    const origWarn = console.warn;
+    console.warn = (msg: string) => warnings.push(msg);
+    try {
+      await readFileContentWithKeys(p1, undefined, { ignoreMatcher: matcher, knownLocales, sourceLocale: 'en' });
+      await readFileContentWithKeys(p2, undefined, { ignoreMatcher: matcher, knownLocales, sourceLocale: 'en' });
+    } finally {
+      console.warn = origWarn;
+    }
+    expect(warnings.filter((w) => w.includes('ignoreKeys does not yet support PO files')).length).toBe(1);
+  });
+
+  it('behaves identically to legacy when no ignoreMatcher is provided (YAML, wrapped)', async () => {
+    const src = 'en:\n  foo: bar\n';
+    const p = path.join(tmp, 'en.yml');
+    await fs.writeFile(p, src, 'utf8');
+    const out = await readFileContentWithKeys(p);
+    expect(out.removed).toEqual([]);
+    expect(out.keys.map((k) => k.name)).toEqual(['en.foo']);
+  });
+
+  it('JSON legacy vs filtered-but-nothing-matches produce identical payload shapes', async () => {
+    const src = JSON.stringify({ en: { foo: { bar: 'x' } } });
+    const p = path.join(tmp, 'en.json');
+    await fs.writeFile(p, src, 'utf8');
+    const nonMatching = createIgnoreMatcher(['no.such.prefix.*']);
+    const legacy = await readFileContentWithKeys(p);
+    const filtered = await readFileContentWithKeys(
+      p,
+      { sourceLanguage: 'en', currentLanguage: 'en' },
+      { ignoreMatcher: nonMatching, knownLocales, sourceLocale: 'en' }
+    );
+    const legacyObj = JSON.parse(Buffer.from(legacy.content, 'base64').toString());
+    const filteredObj = JSON.parse(Buffer.from(filtered.content, 'base64').toString());
+    expect(filteredObj).toEqual(legacyObj);
+    expect(filtered.removed).toEqual([]);
+  });
+});

--- a/tests/utils/import-service.test.ts
+++ b/tests/utils/import-service.test.ts
@@ -143,6 +143,22 @@ describe('readFileContentWithKeys with ignoreMatcher', () => {
     expect(warnings.filter((w) => w.includes('ignoreKeys does not yet support PO files')).length).toBe(1);
   });
 
+  it('does not warn on PO files when matcher does not match any msgid', async () => {
+    const src = 'msgid "some_unrelated_string"\nmsgstr "bar"\n';
+    const p = path.join(tmp, 'unrelated.po');
+    await fs.writeFile(p, src, 'utf8');
+    const matcher = createIgnoreMatcher(['activerecord.errors.*']);
+    const warnings: string[] = [];
+    const origWarn = console.warn;
+    console.warn = (msg: string) => warnings.push(msg);
+    try {
+      await readFileContentWithKeys(p, undefined, { ignoreMatcher: matcher, knownLocales, sourceLocale: 'en' });
+    } finally {
+      console.warn = origWarn;
+    }
+    expect(warnings.filter((w) => w.includes('ignoreKeys'))).toEqual([]);
+  });
+
   it('behaves identically to legacy when no ignoreMatcher is provided (YAML, wrapped)', async () => {
     const src = 'en:\n  foo: bar\n';
     const p = path.join(tmp, 'en.yml');

--- a/tests/utils/json-multi-language.test.ts
+++ b/tests/utils/json-multi-language.test.ts
@@ -78,3 +78,51 @@ describe('JSON multi-language sequential writes', () => {
     expect(after.sv).toEqual({ ...before.sv, cta: 'Signera' });
   });
 });
+
+describe('JSON handler with flat files that have 2-letter object keys', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'localhero-flat-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('does not wrap a flat file with a single 2-letter object-valued key when the target locale is absent', async () => {
+    const filePath = path.join(tempDir, 'sv.json');
+    const initial = {
+      id: { type: 'uuid', value: 'abc' },
+      greeting: 'Hej'
+    };
+    await fs.writeFile(filePath, JSON.stringify(initial, null, 2), 'utf8');
+
+    await updateTranslationFile(filePath, { farewell: 'Hej då' }, 'sv', filePath, 'en');
+
+    const after = JSON.parse(await fs.readFile(filePath, 'utf8'));
+
+    expect(after).toEqual({
+      id: { type: 'uuid', value: 'abc' },
+      greeting: 'Hej',
+      farewell: 'Hej då'
+    });
+    expect(after.sv).toBeUndefined();
+  });
+
+  it('wraps the new locale when 2+ locale-shape sibling entries already exist', async () => {
+    const filePath = path.join(tempDir, 'greet.i18n.json');
+    const initial = {
+      en: { greeting: 'Hello' },
+      sv: { greeting: 'Hej' }
+    };
+    await fs.writeFile(filePath, JSON.stringify(initial, null, 2), 'utf8');
+
+    await updateTranslationFile(filePath, { greeting: 'Hei' }, 'nb', filePath, 'en');
+
+    const after = JSON.parse(await fs.readFile(filePath, 'utf8'));
+
+    expect(Object.keys(after).sort()).toEqual(['en', 'nb', 'sv']);
+    expect(after.nb).toEqual({ greeting: 'Hei' });
+  });
+});

--- a/tests/utils/json-multi-language.test.ts
+++ b/tests/utils/json-multi-language.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { promises as fs } from 'fs';
+import path from 'path';
+import os from 'os';
+import { updateTranslationFile } from '../../src/utils/translation-updater/index.js';
+
+describe('JSON multi-language sequential writes', () => {
+  let tempDir: string;
+  let multiLangPath: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'localhero-multi-'));
+    multiLangPath = path.join(tempDir, 'invite.i18n.json');
+    const initial = {
+      en: { subject: "You've been invited", title: 'Sign your document' },
+      sv: { subject: 'Du har blivit inbjuden', title: 'Signera dokumentet' },
+      nb: { subject: 'Du har blitt invitert', title: 'Signer dokumentet ditt' },
+      fi: { subject: 'Sinut on kutsuttu', title: 'Allekirjoita asiakirjasi' }
+    };
+    await fs.writeFile(multiLangPath, JSON.stringify(initial, null, 2), 'utf8');
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('sequential updates to three target locales preserve the source locale untouched', async () => {
+    const sourceFilePath = multiLangPath;
+
+    await updateTranslationFile(multiLangPath, { cta_button: 'Granska och signera' }, 'sv', sourceFilePath, 'en');
+    await updateTranslationFile(multiLangPath, { cta_button: 'Gjennomgå og signer' }, 'nb', sourceFilePath, 'en');
+    await updateTranslationFile(multiLangPath, { cta_button: 'Tarkista ja allekirjoita' }, 'fi', sourceFilePath, 'en');
+
+    const final = JSON.parse(await fs.readFile(multiLangPath, 'utf8'));
+
+    expect(Object.keys(final).sort()).toEqual(['en', 'fi', 'nb', 'sv']);
+
+    expect(final.en).toEqual({ subject: "You've been invited", title: 'Sign your document' });
+
+    expect(final.sv).toEqual({
+      subject: 'Du har blivit inbjuden',
+      title: 'Signera dokumentet',
+      cta_button: 'Granska och signera'
+    });
+    expect(final.nb).toEqual({
+      subject: 'Du har blitt invitert',
+      title: 'Signer dokumentet ditt',
+      cta_button: 'Gjennomgå og signer'
+    });
+    expect(final.fi).toEqual({
+      subject: 'Sinut on kutsuttu',
+      title: 'Allekirjoita asiakirjasi',
+      cta_button: 'Tarkista ja allekirjoita'
+    });
+  });
+
+  it('preserves the top-level locale insertion order after sequential writes', async () => {
+    const sourceFilePath = multiLangPath;
+    await updateTranslationFile(multiLangPath, { extra: 'x' }, 'sv', sourceFilePath, 'en');
+    await updateTranslationFile(multiLangPath, { extra: 'x' }, 'nb', sourceFilePath, 'en');
+    await updateTranslationFile(multiLangPath, { extra: 'x' }, 'fi', sourceFilePath, 'en');
+
+    const rawAfter = await fs.readFile(multiLangPath, 'utf8');
+    const parsedAfter = JSON.parse(rawAfter);
+    expect(Object.keys(parsedAfter)).toEqual(['en', 'sv', 'nb', 'fi']);
+  });
+
+  it('does not touch other locales when updating one, even when adding a new key', async () => {
+    const sourceFilePath = multiLangPath;
+    const before = JSON.parse(await fs.readFile(multiLangPath, 'utf8'));
+
+    await updateTranslationFile(multiLangPath, { cta: 'Signera' }, 'sv', sourceFilePath, 'en');
+
+    const after = JSON.parse(await fs.readFile(multiLangPath, 'utf8'));
+    expect(after.en).toEqual(before.en);
+    expect(after.nb).toEqual(before.nb);
+    expect(after.fi).toEqual(before.fi);
+    expect(after.sv).toEqual({ ...before.sv, cta: 'Signera' });
+  });
+});

--- a/tests/utils/missing-locale.test.ts
+++ b/tests/utils/missing-locale.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { promises as fs } from 'fs';
+import path from 'path';
+import os from 'os';
+import { updateTranslationFile } from '../../src/utils/translation-updater/index.js';
+
+describe('YAML missing-locale write creates a new top-level locale key', () => {
+  let tempDir: string;
+  let filePath: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'localhero-missing-'));
+    filePath = path.join(tempDir, 'greet.i18n.yml');
+    const initial = `---
+en:
+  greeting: Hello
+sv:
+  greeting: Hej
+`;
+    await fs.writeFile(filePath, initial, 'utf8');
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('adds a new nb: block when sync writes to a locale not already in the file', async () => {
+    await updateTranslationFile(filePath, { greeting: 'Hei' }, 'nb', filePath, 'en');
+
+    const after = await fs.readFile(filePath, 'utf8');
+
+    expect(after).toContain('en:');
+    expect(after).toContain('sv:');
+    expect(after).toContain('nb:');
+
+    expect(after).toContain('  greeting: Hello');
+    expect(after).toContain('  greeting: Hej');
+
+    expect(after).toMatch(/nb:\n\s+greeting:/);
+    expect(after).toContain('Hei');
+
+    expect(after).not.toContain('fi:');
+  });
+});
+
+describe('JSON missing-locale write creates a new top-level locale key', () => {
+  let tempDir: string;
+  let filePath: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'localhero-missing-'));
+    filePath = path.join(tempDir, 'greet.i18n.json');
+    const initial = {
+      en: { greeting: 'Hello' },
+      sv: { greeting: 'Hej' }
+    };
+    await fs.writeFile(filePath, JSON.stringify(initial, null, 2), 'utf8');
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('adds a new nb key when sync writes to a locale not already in the file', async () => {
+    await updateTranslationFile(filePath, { greeting: 'Hei' }, 'nb', filePath, 'en');
+
+    const after = JSON.parse(await fs.readFile(filePath, 'utf8'));
+
+    expect(Object.keys(after).sort()).toEqual(['en', 'nb', 'sv']);
+    expect(after.en).toEqual({ greeting: 'Hello' });
+    expect(after.sv).toEqual({ greeting: 'Hej' });
+    expect(after.nb).toEqual({ greeting: 'Hei' });
+  });
+});

--- a/tests/utils/multi-language-detection.test.ts
+++ b/tests/utils/multi-language-detection.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from '@jest/globals';
+import { detectMultiLanguage } from '../../src/utils/multi-language-detection.js';
+
+describe('detectMultiLanguage', () => {
+  const locales = ['en', 'sv', 'nb', 'fi'];
+
+  it('returns true when every top-level key is a known locale and there are at least 2', () => {
+    expect(detectMultiLanguage({ en: {}, sv: {}, nb: {}, fi: {} }, locales)).toBe(true);
+    expect(detectMultiLanguage({ en: {}, sv: {} }, locales)).toBe(true);
+  });
+
+  it('returns false when only one top-level locale key (single-lang wrapped)', () => {
+    expect(detectMultiLanguage({ en: { subject: 'hi' } }, locales)).toBe(false);
+  });
+
+  it('returns false when any top-level key is not a known locale', () => {
+    expect(detectMultiLanguage({ en: {}, sv: {}, users: {} }, locales)).toBe(false);
+  });
+
+  it('returns false for empty object', () => {
+    expect(detectMultiLanguage({}, locales)).toBe(false);
+  });
+
+  it('returns false for null/undefined/arrays/scalars', () => {
+    expect(detectMultiLanguage(null, locales)).toBe(false);
+    expect(detectMultiLanguage(undefined, locales)).toBe(false);
+    expect(detectMultiLanguage([], locales)).toBe(false);
+    expect(detectMultiLanguage('hello', locales)).toBe(false);
+    expect(detectMultiLanguage(42, locales)).toBe(false);
+  });
+
+  it('accepts a subset of known locales (no equality requirement)', () => {
+    expect(detectMultiLanguage({ en: {}, sv: {}, nb: {} }, locales)).toBe(true);
+  });
+
+  it('is case-sensitive — does NOT match uppercase or mismatched-case locale keys', () => {
+    expect(detectMultiLanguage({ EN: {}, SV: {} }, locales)).toBe(false);
+    expect(detectMultiLanguage({ En: {}, sv: {} }, locales)).toBe(false);
+  });
+
+  it('handles regional locale codes like pt-BR exactly', () => {
+    expect(detectMultiLanguage({ 'pt-BR': {}, en: {} }, ['pt-BR', 'en'])).toBe(true);
+    expect(detectMultiLanguage({ 'pt-br': {}, en: {} }, ['pt-BR', 'en'])).toBe(false);
+  });
+
+  it('returns false when knownLocales is empty', () => {
+    expect(detectMultiLanguage({ en: {}, sv: {} }, [])).toBe(false);
+  });
+});

--- a/tests/utils/translation-updater/concurrent-writes.test.ts
+++ b/tests/utils/translation-updater/concurrent-writes.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { promises as fs } from 'fs';
+import path from 'path';
+import os from 'os';
+import { updateTranslationFile } from '../../../src/utils/translation-updater/index.js';
+import { resetPathSerializer } from '../../../src/utils/translation-updater/path-serializer.js';
+
+const INITIAL_CONTENT = `---
+en:
+  headline: "You've been invited"
+  subject: 'Sign your invitation'
+  body: 'Review the document and confirm with a single click.'
+  cta_button: 'Review and sign'
+sv:
+  headline: 'Du har blivit inbjuden'
+  subject: 'Signera din inbjudan'
+  body: 'Granska dokumentet och bekräfta med ett klick.'
+nb:
+  headline: 'Du har blitt invitert'
+  subject: 'Signer invitasjonen'
+  body: 'Gjennomgå dokumentet og bekreft med ett klikk.'
+fi:
+  headline: 'Sinut on kutsuttu'
+  subject: 'Allekirjoita kutsu'
+  body: 'Tarkista asiakirja ja vahvista yhdellä napsautuksella.'
+`;
+
+describe('concurrent writes to the same multi-language file', () => {
+  let tempDir: string;
+  let filePath: string;
+
+  beforeEach(async () => {
+    resetPathSerializer();
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'localhero-concurrent-'));
+    filePath = path.join(tempDir, 'invite.i18n.yml');
+    await fs.writeFile(filePath, INITIAL_CONTENT, 'utf8');
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('three concurrent updateTranslationFile calls on same path all land in the final file', async () => {
+    await Promise.all([
+      updateTranslationFile(filePath, { cta_button: 'Granska och signera' }, 'sv', filePath, 'en'),
+      updateTranslationFile(filePath, { cta_button: 'Gå gjennom og signer' }, 'nb', filePath, 'en'),
+      updateTranslationFile(filePath, { cta_button: 'Tarkista ja allekirjoita' }, 'fi', filePath, 'en'),
+    ]);
+
+    const after = await fs.readFile(filePath, 'utf8');
+
+    expect(after).toContain('Granska och signera');
+    expect(after).toContain('Gå gjennom og signer');
+    expect(after).toContain('Tarkista ja allekirjoita');
+
+    const svBlock = after.match(/^sv:[\s\S]*?^(?=[a-z]{2}:)/m)?.[0] ?? '';
+    const nbBlock = after.match(/^nb:[\s\S]*?^(?=[a-z]{2}:)/m)?.[0] ?? '';
+    const fiBlock = after.match(/^fi:[\s\S]*$/m)?.[0] ?? '';
+    expect(svBlock).toContain('Granska och signera');
+    expect(nbBlock).toContain('Gå gjennom og signer');
+    expect(fiBlock).toContain('Tarkista ja allekirjoita');
+  });
+
+  it('path-serialized writes to different paths still run in parallel', async () => {
+    const file2 = path.join(tempDir, 'other.i18n.yml');
+    await fs.writeFile(file2, "en:\n  greeting: 'Hello'\nsv:\n  greeting: 'Hej'\n", 'utf8');
+
+    await Promise.all([
+      updateTranslationFile(filePath, { cta_button: 'sv-translation' }, 'sv', filePath, 'en'),
+      updateTranslationFile(file2, { greeting: 'Hej världen' }, 'sv', file2, 'en'),
+    ]);
+
+    const file1After = await fs.readFile(filePath, 'utf8');
+    const file2After = await fs.readFile(file2, 'utf8');
+
+    expect(file1After).toContain('sv-translation');
+    expect(file2After).toContain('Hej världen');
+  });
+});

--- a/tests/utils/translation-updater/path-serializer.test.ts
+++ b/tests/utils/translation-updater/path-serializer.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import { runSerializedByPath, resetPathSerializer } from '../../../src/utils/translation-updater/path-serializer.js';
+
+describe('runSerializedByPath', () => {
+  beforeEach(() => resetPathSerializer());
+
+  it('runs sequential calls for the same path in order', async () => {
+    const order: number[] = [];
+    await Promise.all([
+      runSerializedByPath('same.yml', async () => { await sleep(20); order.push(1); }),
+      runSerializedByPath('same.yml', async () => { await sleep(10); order.push(2); }),
+      runSerializedByPath('same.yml', async () => { await sleep(1); order.push(3); }),
+    ]);
+    expect(order).toEqual([1, 2, 3]);
+  });
+
+  it('runs calls for different paths in parallel', async () => {
+    const order: string[] = [];
+    await Promise.all([
+      runSerializedByPath('a.yml', async () => { await sleep(30); order.push('a'); }),
+      runSerializedByPath('b.yml', async () => { await sleep(10); order.push('b'); }),
+    ]);
+    expect(order).toEqual(['b', 'a']);
+  });
+
+  it('continues processing the queue after an error in a previous call', async () => {
+    const order: string[] = [];
+    const p1 = runSerializedByPath('same.yml', async () => {
+      await sleep(5);
+      throw new Error('boom');
+    });
+    const p2 = runSerializedByPath('same.yml', async () => {
+      order.push('ran');
+      return 'ok';
+    });
+
+    await expect(p1).rejects.toThrow('boom');
+    await expect(p2).resolves.toBe('ok');
+    expect(order).toEqual(['ran']);
+  });
+
+  it('propagates the return value of the inner function', async () => {
+    const result = await runSerializedByPath('x.yml', async () => 42);
+    expect(result).toBe(42);
+  });
+});
+
+function sleep(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/tests/utils/translation-utils.test.js
+++ b/tests/utils/translation-utils.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, jest } from '@jest/globals';
 import { findMissingTranslations, batchKeysWithMissing, generateTargetPath, findMissingTranslationsByLocale, processLocaleTranslations } from '../../src/utils/translation-utils.js';
 import { findMissingPoTranslations, createUniqueKey } from '../../src/utils/po-utils.js';
+import { createIgnoreMatcher } from '../../src/utils/ignore-keys.js';
 
 const createBase64Content = (data) => Buffer.from(JSON.stringify(data)).toString('base64');
 
@@ -212,7 +213,7 @@ describe('translation-utils', () => {
 
       const mockLogger = createMockLogger();
 
-      const result = findMissingTranslationsByLocale(
+      const { missing } = findMissingTranslationsByLocale(
         sourceFiles,
         targetFilesByLocale,
         config,
@@ -221,22 +222,22 @@ describe('translation-utils', () => {
       );
 
       // Check French missing translations
-      expect(result['fr:locales/en.json']).toBeDefined();
-      expect(result['fr:locales/en.json'].locale).toBe('fr');
-      expect(result['fr:locales/en.json'].path).toBe('locales/en.json');
-      expect(result['fr:locales/en.json'].targetPath).toBe('locales/fr.json');
-      expect(Object.keys(result['fr:locales/en.json'].keys)).toContain('goodbye');
-      expect(Object.keys(result['fr:locales/en.json'].keys)).toContain('hello');
-      expect(Object.keys(result['fr:locales/en.json'].keys)).not.toContain('welcome');
+      expect(missing['fr:locales/en.json']).toBeDefined();
+      expect(missing['fr:locales/en.json'].locale).toBe('fr');
+      expect(missing['fr:locales/en.json'].path).toBe('locales/en.json');
+      expect(missing['fr:locales/en.json'].targetPath).toBe('locales/fr.json');
+      expect(Object.keys(missing['fr:locales/en.json'].keys)).toContain('goodbye');
+      expect(Object.keys(missing['fr:locales/en.json'].keys)).toContain('hello');
+      expect(Object.keys(missing['fr:locales/en.json'].keys)).not.toContain('welcome');
 
       // Check Spanish missing translations
-      expect(result['es:locales/en.json']).toBeDefined();
-      expect(result['es:locales/en.json'].locale).toBe('es');
-      expect(result['es:locales/en.json'].path).toBe('locales/en.json');
-      expect(result['es:locales/en.json'].targetPath).toBe('locales/es.json');
-      expect(Object.keys(result['es:locales/en.json'].keys)).toContain('goodbye');
-      expect(Object.keys(result['es:locales/en.json'].keys)).not.toContain('hello');
-      expect(Object.keys(result['es:locales/en.json'].keys)).not.toContain('welcome');
+      expect(missing['es:locales/en.json']).toBeDefined();
+      expect(missing['es:locales/en.json'].locale).toBe('es');
+      expect(missing['es:locales/en.json'].path).toBe('locales/en.json');
+      expect(missing['es:locales/en.json'].targetPath).toBe('locales/es.json');
+      expect(Object.keys(missing['es:locales/en.json'].keys)).toContain('goodbye');
+      expect(Object.keys(missing['es:locales/en.json'].keys)).not.toContain('hello');
+      expect(Object.keys(missing['es:locales/en.json'].keys)).not.toContain('welcome');
     });
 
     it('should handle source files with nested locale structure', () => {
@@ -271,17 +272,17 @@ describe('translation-utils', () => {
 
       const config = createConfig('en', ['fr']);
 
-      const result = findMissingTranslationsByLocale(
+      const { missing } = findMissingTranslationsByLocale(
         sourceFiles,
         targetFilesByLocale,
         config,
         false
       );
 
-      expect(result['fr:locales/en.json']).toBeDefined();
-      expect(result['fr:locales/en.json'].locale).toBe('fr');
-      expect(Object.keys(result['fr:locales/en.json'].keys)).toContain('goodbye');
-      expect(Object.keys(result['fr:locales/en.json'].keys)).not.toContain('welcome');
+      expect(missing['fr:locales/en.json']).toBeDefined();
+      expect(missing['fr:locales/en.json'].locale).toBe('fr');
+      expect(Object.keys(missing['fr:locales/en.json'].keys)).toContain('goodbye');
+      expect(Object.keys(missing['fr:locales/en.json'].keys)).not.toContain('welcome');
     });
 
     it('should handle source files with invalid or missing content', () => {
@@ -313,7 +314,7 @@ describe('translation-utils', () => {
 
       const config = createConfig('en', ['fr']);
 
-      const result = findMissingTranslationsByLocale(
+      const { missing } = findMissingTranslationsByLocale(
         sourceFiles,
         targetFilesByLocale,
         config,
@@ -321,9 +322,51 @@ describe('translation-utils', () => {
       );
 
       // Should skip file with missing content, still process valid file
-      expect(result['fr:locales/en.json']).toBeUndefined();
-      expect(result['fr:locales/en2.json']).toBeDefined();
-      expect(result['fr:locales/en2.json'].keys.welcome).toBeDefined();
+      expect(missing['fr:locales/en.json']).toBeUndefined();
+      expect(missing['fr:locales/en2.json']).toBeDefined();
+      expect(missing['fr:locales/en2.json'].keys.welcome).toBeDefined();
+    });
+
+    it('skips keys matched by ignoreMatcher and returns removed list', () => {
+      const sourceFiles = [
+        {
+          path: 'locales/en.json',
+          format: 'json',
+          content: createBase64Content({
+            navigation: { home: 'Home' },
+            activerecord: { errors: { foo: 'oops' } }
+          })
+        }
+      ];
+
+      const targetFilesByLocale = {
+        sv: []
+      };
+
+      const config = createConfig('en', ['sv']);
+      const ignoreMatcher = createIgnoreMatcher(['activerecord.errors.*']);
+
+      const result = findMissingTranslationsByLocale(
+        sourceFiles,
+        targetFilesByLocale,
+        config,
+        false,
+        createMockLogger(),
+        { ignoreMatcher }
+      );
+
+      expect(result.missing['sv:locales/en.json']).toBeDefined();
+      const missingKeys = Object.keys(result.missing['sv:locales/en.json'].keys);
+      expect(missingKeys).toContain('navigation.home');
+      expect(missingKeys).not.toContain('activerecord.errors.foo');
+
+      expect(result.removed).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: 'activerecord.errors.foo' })
+        ])
+      );
+      const removedForSource = result.removed.find((r) => r.name === 'activerecord.errors.foo');
+      expect(removedForSource.locale).toBeUndefined();
     });
   });
 

--- a/tests/utils/translation-utils.test.js
+++ b/tests/utils/translation-utils.test.js
@@ -99,6 +99,73 @@ describe('translation-utils', () => {
         }
       });
     });
+
+    describe('blank source placeholders', () => {
+      it('string branch: empty string source is skipped with reason blank_source', () => {
+        const sourceKeys = {
+          real_key: 'Hello',
+          placeholder: ''
+        };
+        const result = findMissingTranslations(sourceKeys, {});
+
+        expect(result.missingKeys).toEqual({
+          real_key: { value: 'Hello', sourceKey: 'real_key' }
+        });
+        expect(result.skippedKeys).toEqual({
+          placeholder: { value: '', reason: 'blank_source' }
+        });
+      });
+
+      it('string branch: whitespace-only source is skipped with reason blank_source', () => {
+        const sourceKeys = { placeholder: '   ' };
+        const result = findMissingTranslations(sourceKeys, {});
+
+        expect(result.missingKeys).toEqual({});
+        expect(result.skippedKeys).toEqual({
+          placeholder: { value: '   ', reason: 'blank_source' }
+        });
+      });
+
+      it('string branch: non-blank source still triggers missing-key detection', () => {
+        const sourceKeys = { greeting: 'Hello' };
+        const result = findMissingTranslations(sourceKeys, {});
+
+        expect(result.missingKeys).toEqual({ greeting: { value: 'Hello', sourceKey: 'greeting' } });
+        expect(result.skippedKeys).toEqual({});
+      });
+
+      it('string branch: WIP markers still produce reason wip (not blank_source)', () => {
+        const sourceKeys = { wip_draft: 'wip_some draft' };
+        const result = findMissingTranslations(sourceKeys, {});
+
+        expect(result.skippedKeys).toEqual({ wip_draft: { value: 'wip_some draft', reason: 'wip' } });
+        expect(result.missingKeys).toEqual({});
+      });
+
+      it('object-with-value branch: empty value string is skipped with reason blank_source', () => {
+        const sourceKeys = { placeholder: { value: '' } };
+        const result = findMissingTranslations(sourceKeys, {});
+
+        expect(result.missingKeys).toEqual({});
+        expect(result.skippedKeys.placeholder).toMatchObject({ value: '', reason: 'blank_source' });
+      });
+
+      it('object-with-value branch: non-blank value flows through to missing-key detection', () => {
+        const sourceKeys = { greeting: { value: 'Hello' } };
+        const result = findMissingTranslations(sourceKeys, {});
+
+        expect(result.missingKeys).toEqual({ greeting: { value: 'Hello', sourceKey: 'greeting' } });
+        expect(result.skippedKeys).toEqual({});
+      });
+
+      it('object-with-value branch: WIP marker in value still produces reason wip', () => {
+        const sourceKeys = { draft: { value: 'wip_some draft' } };
+        const result = findMissingTranslations(sourceKeys, {});
+
+        expect(result.skippedKeys).toEqual({ draft: { value: 'wip_some draft', reason: 'wip' } });
+        expect(result.missingKeys).toEqual({});
+      });
+    });
   });
 
   describe('findMissingTranslationsByLocale', () => {

--- a/tests/utils/yaml-multi-language.test.ts
+++ b/tests/utils/yaml-multi-language.test.ts
@@ -128,7 +128,7 @@ describe('YAML multi-language sequential writes preserve Qasa-shape formatting',
     expect(fiBlock).toContain("  subject: ''");
     expect(fiBlock).toContain("  headline: ''");
 
-    expect(raw).toMatch(/subject: '?Du har blivit inbjuden'?/);
+    expect(raw).toMatch(/^ {2}subject: 'Du har blivit inbjuden'$/m);
   });
 
   it('source locale stays untouched when target-lang change matches English value', async () => {

--- a/tests/utils/yaml-multi-language.test.ts
+++ b/tests/utils/yaml-multi-language.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { promises as fs } from 'fs';
+import path from 'path';
+import os from 'os';
+import { updateTranslationFile } from '../../src/utils/translation-updater/index.js';
+
+const QASA_SHAPE = `---
+en:
+  headline: ''
+  subject: Invitation
+sv:
+  headline: ''
+  subject: ''
+nb:
+  headline: ''
+  subject: ''
+fi:
+  headline: ''
+  subject: ''
+`;
+
+function extractBlock(raw: string, locale: string): string[] {
+  const lines = raw.split('\n');
+  const startIndex = lines.findIndex(l => l === `${locale}:`);
+  if (startIndex === -1) return [];
+
+  const block: string[] = [lines[startIndex]];
+  for (let i = startIndex + 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.length > 0 && !line.startsWith(' ') && !line.startsWith('\t')) {
+      break;
+    }
+    block.push(line);
+  }
+  return block;
+}
+
+describe('YAML multi-language sequential writes preserve Qasa-shape formatting', () => {
+  let tempDir: string;
+  let multiLangPath: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'localhero-yaml-multi-'));
+    multiLangPath = path.join(tempDir, 'invite.i18n.yml');
+    await fs.writeFile(multiLangPath, QASA_SHAPE, 'utf8');
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('preserves formatting across three sequential writes adding cta_button to sv/nb/fi', async () => {
+    const sourceFilePath = multiLangPath;
+
+    await updateTranslationFile(multiLangPath, { cta_button: 'Granska och signera' }, 'sv', sourceFilePath, 'en');
+    await updateTranslationFile(multiLangPath, { cta_button: 'Gjennomgå og signer' }, 'nb', sourceFilePath, 'en');
+    await updateTranslationFile(multiLangPath, { cta_button: 'Tarkista ja allekirjoita' }, 'fi', sourceFilePath, 'en');
+
+    const raw = await fs.readFile(multiLangPath, 'utf8');
+
+    expect(raw.startsWith('---\n')).toBe(true);
+
+    const lines = raw.split('\n');
+    const topLevelLocales = lines
+      .filter(l => /^[a-z]{2,3}(-[A-Z]{2})?:$/.test(l))
+      .map(l => l.replace(':', ''));
+    expect(topLevelLocales).toEqual(['en', 'sv', 'nb', 'fi']);
+
+    const originalLines = QASA_SHAPE.split('\n');
+    const originalLineCount = originalLines.filter(l => l.length > 0).length;
+    const actualLineCount = lines.filter(l => l.length > 0).length;
+    expect(actualLineCount).toBe(originalLineCount + 3);
+
+    const enBlockBefore = extractBlock(QASA_SHAPE, 'en');
+    const enBlockAfter = extractBlock(raw, 'en');
+    expect(enBlockAfter).toEqual(enBlockBefore);
+
+    expect(raw).toMatch(/^ {2}headline: ''$/m);
+    expect(raw).not.toMatch(/headline: ""/);
+    expect(raw).not.toMatch(/^\t/m);
+
+    expect(raw).toContain('cta_button: Granska och signera');
+    expect(raw).toContain('cta_button: Gjennomgå og signer');
+    expect(raw).toContain('cta_button: Tarkista ja allekirjoita');
+  });
+
+  it('single write to sv adds exactly one line; other locales unchanged verbatim', async () => {
+    const sourceFilePath = multiLangPath;
+    const before = await fs.readFile(multiLangPath, 'utf8');
+
+    await updateTranslationFile(multiLangPath, { cta_button: 'Signera' }, 'sv', sourceFilePath, 'en');
+
+    const after = await fs.readFile(multiLangPath, 'utf8');
+    const beforeLines = before.split('\n');
+    const afterLines = after.split('\n');
+
+    expect(afterLines.length).toBe(beforeLines.length + 1);
+
+    const enBefore = extractBlock(before, 'en');
+    const enAfter = extractBlock(after, 'en');
+    expect(enAfter).toEqual(enBefore);
+
+    const nbBefore = extractBlock(before, 'nb');
+    const nbAfter = extractBlock(after, 'nb');
+    expect(nbAfter).toEqual(nbBefore);
+
+    const fiBefore = extractBlock(before, 'fi');
+    const fiAfter = extractBlock(after, 'fi');
+    expect(fiAfter).toEqual(fiBefore);
+
+    expect(after).toContain('cta_button: Signera');
+  });
+
+  it('updating an existing key value does not reformat other values', async () => {
+    const sourceFilePath = multiLangPath;
+
+    await updateTranslationFile(multiLangPath, { subject: 'Du har blivit inbjuden' }, 'sv', sourceFilePath, 'en');
+
+    const raw = await fs.readFile(multiLangPath, 'utf8');
+
+    expect(raw).toMatch(/^ {2}subject: Invitation$/m);
+
+    const nbBlock = extractBlock(raw, 'nb');
+    expect(nbBlock).toContain("  subject: ''");
+    expect(nbBlock).toContain("  headline: ''");
+
+    const fiBlock = extractBlock(raw, 'fi');
+    expect(fiBlock).toContain("  subject: ''");
+    expect(fiBlock).toContain("  headline: ''");
+
+    expect(raw).toMatch(/subject: '?Du har blivit inbjuden'?/);
+  });
+
+  it('source locale stays untouched when target-lang change matches English value', async () => {
+    const sourceFilePath = multiLangPath;
+    const initial = `---
+en:
+  greeting: Hello
+sv:
+  greeting: ''
+`;
+    await fs.writeFile(multiLangPath, initial, 'utf8');
+
+    await updateTranslationFile(multiLangPath, { greeting: 'Hello' }, 'sv', sourceFilePath, 'en');
+
+    const raw = await fs.readFile(multiLangPath, 'utf8');
+
+    const enBlockBefore = extractBlock(initial, 'en');
+    const enBlockAfter = extractBlock(raw, 'en');
+    expect(enBlockAfter).toEqual(enBlockBefore);
+
+    expect(raw).toContain('sv:');
+    expect(raw).toMatch(/sv:\n {2}greeting: '?Hello'?/);
+  });
+});


### PR DESCRIPTION
- Multi-language YAML/JSON files: one file per locale set, top-level locale keys (opt-in  via translationFiles.multiLanguageFiles)
- ignoreKeys: skip patterns during push and translate (translationFiles.ignoreKeys)