### PR TITLE
Ensure changed keys are the actual changed

### DIFF
--- a/src/utils/git-changes.ts
+++ b/src/utils/git-changes.ts
@@ -112,17 +112,22 @@ export function filterByGitChanges(
       return null;
     }
 
-    // Get changed keys from source files
-    const changedKeys = getChangedKeys(sourceFiles, baseBranch, verbose);
+    // Get changed keys from source files (per-file scoped)
+    const changedKeysByFile = getChangedKeys(sourceFiles, baseBranch, verbose);
 
-    if (changedKeys === null) {
+    if (changedKeysByFile === null) {
       if (verbose) {
         console.log(chalk.yellow('Could not determine changed keys (limit exceeded or error)'));
       }
       return null;
     }
 
-    if (changedKeys.size === 0) {
+    let totalChangedKeys = 0;
+    for (const keys of changedKeysByFile.values()) {
+      totalChangedKeys += keys.size;
+    }
+
+    if (totalChangedKeys === 0) {
       if (verbose) {
         console.log(chalk.dim('No changes detected in source files'));
       }
@@ -130,20 +135,25 @@ export function filterByGitChanges(
     }
 
     if (verbose) {
-      console.log(chalk.blue(`Found ${changedKeys.size} changed key${changedKeys.size === 1 ? '' : 's'}:`));
+      console.log(chalk.blue(`Found ${totalChangedKeys} changed key${totalChangedKeys === 1 ? '' : 's'}:`));
 
-      const keysArray = Array.from(changedKeys);
-      const displayKeys = keysArray.slice(0, 10);
+      const flatKeys: string[] = [];
+      for (const [filePath, keys] of changedKeysByFile.entries()) {
+        for (const key of keys) {
+          flatKeys.push(`${filePath}:${key}`);
+        }
+      }
+      const displayKeys = flatKeys.slice(0, 10);
 
       displayKeys.forEach(key => {
         console.log(chalk.dim(`  - ${key}`));
       });
-      if (keysArray.length > 10) {
-        console.log(chalk.dim(`  ... and ${keysArray.length - 10} more`));
+      if (flatKeys.length > 10) {
+        console.log(chalk.dim(`  ... and ${flatKeys.length - 10} more`));
       }
     }
 
-    return filterMissing(missingByLocale, changedKeys);
+    return filterMissing(missingByLocale, changedKeysByFile);
   } catch (error) {
     if (verbose) {
       const err = error as Error;
@@ -203,7 +213,21 @@ export function getChangedKeysForProject(
     return null;
   }
 
-  return getChangedKeys(sourceFiles, baseBranch, verbose);
+  const perFile = getChangedKeys(sourceFiles, baseBranch, verbose);
+  if (perFile === null) return null;
+
+  // `pull --changed-only` filters target-file updates by bare key name,
+  // so we flatten the per-file map. The cross-file false-positive bug
+  // this avoids in `translate` doesn't apply here: `pull` is filtering
+  // already-translated payloads coming back from the server, not
+  // deciding which source files to send for translation.
+  const flat = new Set<string>();
+  for (const keys of perFile.values()) {
+    for (const key of keys) {
+      flat.add(key);
+    }
+  }
+  return flat;
 }
 
 /**
@@ -344,17 +368,26 @@ function diffFileKeys(
  * Get all changed keys from source files using object-based diff.
  * Compares parsed and flattened objects from base branch vs current working directory.
  */
+/**
+ * Returns a Map of source file path -> Set of keys changed in THAT file.
+ *
+ * Per-file scoping is critical: many repos have files that share top-level
+ * key names (e.g. each email template has its own `subject`, `body`). A
+ * flat global Set would cause a new key in one file to falsely match
+ * missing translations of the same bare name in unrelated files.
+ */
 function getChangedKeys(
   sourceFiles: TranslationFile[],
   baseBranch: string,
   verbose: boolean
-): Set<string> | null {
+): Map<string, Set<string>> | null {
   const resolvedRef = resolveCompareRef(baseBranch, verbose);
   if (!resolvedRef) {
     return null;
   }
 
-  const allChangedKeys = new Set<string>();
+  const changedKeysByFile = new Map<string, Set<string>>();
+  let totalChangedKeys = 0;
   const MAX_CHANGED_KEYS = 10000;
 
   for (const file of sourceFiles) {
@@ -365,23 +398,29 @@ function getChangedKeys(
       const { oldFlat, newFlat } = diff;
       const fileChangedKeys: string[] = [];
       let totalChangedInFile = 0;
+      const perFileSet = new Set<string>();
 
       for (const [key, value] of Object.entries(newFlat)) {
         if (!(key in oldFlat) || oldFlat[key] !== value) {
-          if (allChangedKeys.size >= MAX_CHANGED_KEYS) {
+          if (totalChangedKeys >= MAX_CHANGED_KEYS) {
             if (verbose) {
               console.log(chalk.yellow(`Warning: Exceeded ${MAX_CHANGED_KEYS} changed keys limit`));
             }
             return null;
           }
 
-          allChangedKeys.add(key);
+          perFileSet.add(key);
+          totalChangedKeys++;
           totalChangedInFile++;
 
           if (verbose && fileChangedKeys.length < 5) {
             fileChangedKeys.push(key);
           }
         }
+      }
+
+      if (perFileSet.size > 0) {
+        changedKeysByFile.set(file.path, perFileSet);
       }
 
       if (verbose && totalChangedInFile > 0) {
@@ -402,7 +441,7 @@ function getChangedKeys(
     }
   }
 
-  return allChangedKeys;
+  return changedKeysByFile;
 }
 
 export interface PerFileDiff {
@@ -719,35 +758,49 @@ export function getRemovedKeysManifestForFinalize(
 }
 
 /**
- * Filter missing translations by changed keys
+ * Filter missing translations by changed keys, scoped per source file.
  *
- * For plural forms, if ANY variant changed, include ALL variants for the target language.
- * This handles cases where source and target languages have different plural form counts.
+ * The scoping is critical: a flat (file-agnostic) match would let a key
+ * introduced in file A falsely pull missing translations of the same bare
+ * name from unrelated file B. Many repos legitimately use the same
+ * top-level key names across files (e.g. each email template has its own
+ * `subject` / `body`), so cross-file matching is incorrect.
+ *
+ * For plural forms, if ANY variant of a base key changed IN THE SAME
+ * SOURCE FILE, include ALL variants for the target language. This handles
+ * cases where source and target languages have different plural form
+ * counts, without leaking across files.
  */
 function filterMissing(
   missingByLocale: Record<string, MissingLocaleEntry>,
-  changedKeys: Set<string>
+  changedKeysByFile: Map<string, Set<string>>
 ): Record<string, MissingLocaleEntry> {
   const filtered: Record<string, MissingLocaleEntry> = {};
 
-  // Extract base keys from plural forms in changedKeys
-  // E.g., "key__plural_1" -> "key"
-  const baseChangedKeys = extractBaseKeys(changedKeys);
+  // Pre-compute the base-key set (plural-stripped) per file. Cheap, and
+  // keeps the inner loop free of repeated regex work.
+  const baseChangedKeysByFile = new Map<string, Set<string>>();
+  for (const [filePath, keys] of changedKeysByFile.entries()) {
+    baseChangedKeysByFile.set(filePath, extractBaseKeys(keys));
+  }
 
   for (const [localeKey, entry] of Object.entries(missingByLocale)) {
+    const changedKeysForThisFile = changedKeysByFile.get(entry.path);
+    if (!changedKeysForThisFile) continue;
+
+    const baseChangedKeysForThisFile = baseChangedKeysByFile.get(entry.path) ?? new Set<string>();
+
     const filteredKeys: Record<string, any> = {};
     let count = 0;
 
     for (const [key, details] of Object.entries(entry.keys)) {
-      if (changedKeys.has(key)) {
+      if (changedKeysForThisFile.has(key)) {
         filteredKeys[key] = details;
         count++;
       } else {
-        // For plural forms, check if base key changed
+        // Plural variant: include only if base key changed IN THIS FILE.
         const baseKey = key.replace(PLURAL_SUFFIX_REGEX, '');
-        if (baseKey !== key && baseChangedKeys.has(baseKey)) {
-          // This is a plural variant of a changed key - include it
-          // even if the source language doesn't have this many plural forms
+        if (baseKey !== key && baseChangedKeysForThisFile.has(baseKey)) {
           filteredKeys[key] = details;
           count++;
         }

--- a/tests/utils/git-changes.test.js
+++ b/tests/utils/git-changes.test.js
@@ -692,6 +692,292 @@ msgstr[1] "Delete items"
 
       expect(result).toEqual({});
     });
+
+    // Regression: previously, getChangedKeys collected bare key names into a
+    // global Set<string>. filterMissing then checked that set without file
+    // scope, so a key like `subject` introduced in file A would falsely match
+    // a pre-existing missing `subject` translation in unrelated file B.
+    // This is common in repos where each file uses its own top-level keys
+    // (e.g. each email template has its own `subject` / `headline` / `body`),
+    // causing a single new file to drag many unrelated files into the
+    // translation pass.
+    it('does NOT match missing keys in a file whose source did not change, even when another file has the same bare key', () => {
+      const multiSourceFiles = [
+        { path: 'emails/welcome.yml', format: 'yml', locale: 'en' },
+        { path: 'emails/reminder.yml', format: 'yml', locale: 'en' }
+      ];
+
+      const welcomeOld = `en:
+  subject: Welcome
+  body: Hi
+`;
+      const welcomeNew = welcomeOld;
+
+      const reminderNew = `en:
+  subject: Reminder
+  body: Hey
+`;
+
+      setupGitMock({
+        showByPath: {
+          'emails/welcome.yml': welcomeOld,
+          'emails/reminder.yml': null
+        }
+      });
+
+      mockReadFileSync.mockImplementation((p) => {
+        if (p.endsWith('emails/welcome.yml')) return welcomeNew;
+        if (p.endsWith('emails/reminder.yml')) return reminderNew;
+        throw new Error(`Unexpected readFileSync path: ${p}`);
+      });
+
+      const missing = {
+        'fr:emails/welcome.yml': {
+          locale: 'fr',
+          path: 'emails/welcome.yml',
+          targetPath: 'emails/welcome.yml',
+          keys: {
+            subject: { value: 'Welcome', sourceKey: 'subject' },
+            body: { value: 'Hi', sourceKey: 'body' }
+          },
+          keyCount: 2
+        },
+        'fr:emails/reminder.yml': {
+          locale: 'fr',
+          path: 'emails/reminder.yml',
+          targetPath: 'emails/reminder.yml',
+          keys: {
+            subject: { value: 'Reminder', sourceKey: 'subject' },
+            body: { value: 'Hey', sourceKey: 'body' }
+          },
+          keyCount: 2
+        }
+      };
+
+      const result = filterByGitChanges(multiSourceFiles, missing, mockConfig, false);
+
+      expect(result['fr:emails/welcome.yml']).toBeUndefined();
+      expect(result['fr:emails/reminder.yml']).toBeDefined();
+      expect(result['fr:emails/reminder.yml'].keyCount).toBe(2);
+    });
+
+    it('scopes per-file: each file passes only its own changed keys', () => {
+      const multiSourceFiles = [
+        { path: 'locales/a.json', format: 'json', locale: 'en' },
+        { path: 'locales/b.json', format: 'json', locale: 'en' }
+      ];
+
+      const aOld = JSON.stringify({ shared: 'a-old' });
+      const aNew = JSON.stringify({ shared: 'a-new', foo: 'A foo' });
+
+      const bOld = JSON.stringify({ shared: 'b' });
+      const bNew = JSON.stringify({ shared: 'b', bar: 'B bar' });
+
+      setupGitMock({
+        showByPath: {
+          'locales/a.json': aOld,
+          'locales/b.json': bOld
+        }
+      });
+
+      mockReadFileSync.mockImplementation((p) => {
+        if (p.endsWith('locales/a.json')) return aNew;
+        if (p.endsWith('locales/b.json')) return bNew;
+        throw new Error(`Unexpected path: ${p}`);
+      });
+
+      // Both files have BOTH `foo` and `bar` "missing" in fr — the filter must
+      // give each file only the key actually added in THAT file.
+      const missing = {
+        'fr:locales/a.json': {
+          locale: 'fr',
+          path: 'locales/a.json',
+          targetPath: 'locales/a.fr.json',
+          keys: {
+            foo: { value: 'A foo', sourceKey: 'foo' },
+            bar: { value: 'B bar', sourceKey: 'bar' }
+          },
+          keyCount: 2
+        },
+        'fr:locales/b.json': {
+          locale: 'fr',
+          path: 'locales/b.json',
+          targetPath: 'locales/b.fr.json',
+          keys: {
+            foo: { value: 'A foo', sourceKey: 'foo' },
+            bar: { value: 'B bar', sourceKey: 'bar' }
+          },
+          keyCount: 2
+        }
+      };
+
+      const result = filterByGitChanges(multiSourceFiles, missing, mockConfig, false);
+
+      // a.json's filter set contains `shared` (value changed) and `foo` (new),
+      // but `shared` isn't in a.json's missing entries, so it's a no-op.
+      // `bar` is in a.json's missing entries but didn't change in a.json,
+      // so it must NOT pass.
+      expect(Object.keys(result['fr:locales/a.json'].keys).sort()).toEqual(['foo']);
+      expect(Object.keys(result['fr:locales/b.json'].keys).sort()).toEqual(['bar']);
+    });
+
+    it('plural variants pass when their base key changed in the SAME file', () => {
+      const sourceFiles = [
+        { path: 'locales/en.json', format: 'json', locale: 'en' }
+      ];
+
+      const oldContent = JSON.stringify({});
+      const newContent = JSON.stringify({ count: 'You have one' });
+
+      setupGitMock({
+        showByPath: { 'locales/en.json': oldContent }
+      });
+      mockReadFileSync.mockReturnValue(newContent);
+
+      const missing = {
+        'fr:locales/en.json': {
+          locale: 'fr',
+          path: 'locales/en.json',
+          targetPath: 'locales/fr.json',
+          keys: {
+            count: { value: 'You have one', sourceKey: 'count' },
+            count__plural_1: { value: 'You have many', sourceKey: 'count' }
+          },
+          keyCount: 2
+        }
+      };
+
+      const result = filterByGitChanges(sourceFiles, missing, mockConfig, false);
+
+      expect(result['fr:locales/en.json'].keys.count).toBeDefined();
+      expect(result['fr:locales/en.json'].keys.count__plural_1).toBeDefined();
+      expect(result['fr:locales/en.json'].keyCount).toBe(2);
+    });
+
+    it('plural variants do NOT pass when the base key did not change in THAT file', () => {
+      const multiSourceFiles = [
+        { path: 'locales/a.json', format: 'json', locale: 'en' },
+        { path: 'locales/b.json', format: 'json', locale: 'en' }
+      ];
+
+      const aOld = JSON.stringify({});
+      const aNew = JSON.stringify({ count: 'A one' });
+
+      const bOld = JSON.stringify({ count: 'B one' });
+      const bNew = bOld;
+
+      setupGitMock({
+        showByPath: {
+          'locales/a.json': aOld,
+          'locales/b.json': bOld
+        }
+      });
+      mockReadFileSync.mockImplementation((p) => {
+        if (p.endsWith('locales/a.json')) return aNew;
+        if (p.endsWith('locales/b.json')) return bNew;
+        throw new Error(`Unexpected path: ${p}`);
+      });
+
+      // b has a missing plural for `count__plural_1` BUT the base `count` in
+      // b did not change. Only a's count plural should pass.
+      const missing = {
+        'fr:locales/a.json': {
+          locale: 'fr',
+          path: 'locales/a.json',
+          targetPath: 'locales/a.fr.json',
+          keys: {
+            count: { value: 'A one', sourceKey: 'count' },
+            count__plural_1: { value: 'A many', sourceKey: 'count' }
+          },
+          keyCount: 2
+        },
+        'fr:locales/b.json': {
+          locale: 'fr',
+          path: 'locales/b.json',
+          targetPath: 'locales/b.fr.json',
+          keys: {
+            count__plural_1: { value: 'B many', sourceKey: 'count' }
+          },
+          keyCount: 1
+        }
+      };
+
+      const result = filterByGitChanges(multiSourceFiles, missing, mockConfig, false);
+
+      expect(result['fr:locales/a.json']).toBeDefined();
+      expect(result['fr:locales/a.json'].keys.count).toBeDefined();
+      expect(result['fr:locales/a.json'].keys.count__plural_1).toBeDefined();
+      expect(result['fr:locales/b.json']).toBeUndefined();
+    });
+
+    it('multi-language source files with overlapping bare keys only translate files where the EN source actually changed', () => {
+      // Multi-language YAML where each email-template file holds en+sv
+      // blocks with its own top-level `subject` / `body` keys. Adding a
+      // brand-new file with the same key names must NOT cause sibling
+      // files to be flagged for translation.
+      const multiSourceFiles = [
+        { path: 'apps/email/welcome.yml', format: 'yml', locale: 'en' },
+        { path: 'apps/email/booking_reminder.yml', format: 'yml', locale: 'en' }
+      ];
+
+      const welcomeOld = `en:
+  subject: Welcome
+  body: Hi there
+sv:
+  subject: Välkommen
+  body: Hej
+`;
+      const welcomeNew = welcomeOld;
+
+      const reminderNew = `en:
+  subject: Booking reminder
+  body: Your viewing is tomorrow
+sv:
+  subject: ''
+  body: ''
+`;
+
+      setupGitMock({
+        showByPath: {
+          'apps/email/welcome.yml': welcomeOld,
+          'apps/email/booking_reminder.yml': null
+        }
+      });
+      mockReadFileSync.mockImplementation((p) => {
+        if (p.endsWith('welcome.yml')) return welcomeNew;
+        if (p.endsWith('booking_reminder.yml')) return reminderNew;
+        throw new Error(`Unexpected path: ${p}`);
+      });
+
+      const missing = {
+        'sv:apps/email/welcome.yml': {
+          locale: 'sv',
+          path: 'apps/email/welcome.yml',
+          targetPath: 'apps/email/welcome.yml',
+          keys: {
+            subject: { value: 'Welcome', sourceKey: 'subject' },
+            body: { value: 'Hi there', sourceKey: 'body' }
+          },
+          keyCount: 2
+        },
+        'sv:apps/email/booking_reminder.yml': {
+          locale: 'sv',
+          path: 'apps/email/booking_reminder.yml',
+          targetPath: 'apps/email/booking_reminder.yml',
+          keys: {
+            subject: { value: 'Booking reminder', sourceKey: 'subject' },
+            body: { value: 'Your viewing is tomorrow', sourceKey: 'body' }
+          },
+          keyCount: 2
+        }
+      };
+
+      const result = filterByGitChanges(multiSourceFiles, missing, mockConfig, false);
+
+      expect(result['sv:apps/email/welcome.yml']).toBeUndefined();
+      expect(result['sv:apps/email/booking_reminder.yml']).toBeDefined();
+      expect(result['sv:apps/email/booking_reminder.yml'].keyCount).toBe(2);
+    });
   });
 
   describe('file filtering', () => {


### PR DESCRIPTION
The bot's "changed keys" list was just names, without remembering which file they came from. So when checking which translations to add, any file with a missing translation for a same-named key got pulled in.