### PR TITLE
Stack signed sync commits instead of amending

### DIFF
--- a/src/utils/github-graphql.ts
+++ b/src/utils/github-graphql.ts
@@ -131,14 +131,11 @@ export async function createSignedCommit(
 
 export interface BranchHead {
   sha: string;
-  parentSha: string | null;
-  authorEmail: string | null;
 }
 
 /**
- * Fetch the current HEAD of a branch via the REST API. Returns the SHA, the
- * parent SHA (for amend semantics), and the author email (to detect whether
- * the last commit was made by the LocalHero bot).
+ * Fetch the current HEAD SHA of a branch via the REST API. Used as the
+ * `expectedHeadOid` precondition for `createCommitOnBranch`.
  */
 export async function fetchBranchHead(
   repositoryNameWithOwner: string,
@@ -165,27 +162,5 @@ export async function fetchBranchHead(
     throw new GitHubGraphQLError(`Branch ${branchName} has no head SHA`);
   }
 
-  const commitUrl = `https://api.github.com/repos/${repositoryNameWithOwner}/commits/${sha}`;
-  const commitResponse = await deps.fetch(commitUrl, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-      Accept: 'application/vnd.github+json',
-      'User-Agent': 'localhero-cli'
-    }
-  });
-
-  if (!commitResponse.ok) {
-    throw new GitHubGraphQLError(`Failed to fetch commit: ${commitResponse.status} ${commitResponse.statusText}`);
-  }
-
-  const commitBody = (await commitResponse.json()) as {
-    parents?: Array<{ sha: string }>;
-    commit?: { author?: { email?: string } };
-  };
-
-  return {
-    sha,
-    parentSha: commitBody.parents?.[0]?.sha ?? null,
-    authorEmail: commitBody.commit?.author?.email ?? null
-  };
+  return { sha };
 }

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -252,20 +252,6 @@ jobs:
     return status.length > 0;
   },
 
-  /**
-   * Check if the last commit was made by LocalHero bot
-   * Used to determine if we can safely amend the commit
-   */
-  isLastCommitByLocalHero(): boolean {
-    const { exec } = this.deps;
-    try {
-      const authorEmail = exec('git log -1 --format=%ae').toString().trim();
-      return authorEmail.includes('localhero');
-    } catch {
-      return false;
-    }
-  },
-
   canAmendLastCommit(isSyncMode: boolean): boolean {
     if (!isSyncMode) return false;
     const { exec } = this.deps;
@@ -366,13 +352,10 @@ jobs:
         const result = await this.apiCommitAndPush({
           branchName,
           filePaths: filesToCommit,
-          message: commitMessage,
-          isSyncMode: true
+          message: commitMessage
         });
         if (result === 'no-changes') {
           log.log('No changes to commit - translations already up to date.');
-        } else if (result === 'amended') {
-          log.log('✓ Commit amended and pushed to GitHub (signed)\n');
         } else {
           log.log('✓ Signed commit created and pushed to GitHub\n');
         }
@@ -473,8 +456,7 @@ jobs:
         const result = await this.apiCommitAndPush({
           branchName,
           filePaths,
-          message: commitMessage,
-          isSyncMode: false
+          message: commitMessage
         });
         if (result === 'no-changes') {
           log.log('No changes to commit.');
@@ -511,16 +493,19 @@ jobs:
    * mutation. Produces signed commits attributed to the LocalHero App. Works
    * with repos that enforce `required_signatures` rulesets.
    *
+   * The new commit is stacked on top of the current branch HEAD. The mutation
+   * has no amend primitive — `expectedHeadOid` is a strict precondition, so
+   * sync PRs end up with two commits (the bot's initial sync trigger commit
+   * plus the CLI's translation commit), squashed at merge.
+   *
    * Returns 'no-changes' if all files match what's already on the branch,
-   * 'amended' if the previous LocalHero sync commit was replaced, otherwise
-   * 'new'.
+   * otherwise 'new'.
    */
   async apiCommitAndPush(params: {
     branchName: string;
     filePaths: string[];
     message: string;
-    isSyncMode: boolean;
-  }): Promise<'no-changes' | 'new' | 'amended'> {
+  }): Promise<'no-changes' | 'new'> {
     const { console: log, env } = this.deps;
 
     const repository = env.GITHUB_REPOSITORY;
@@ -540,28 +525,18 @@ jobs:
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
       try {
         const head = await this.deps.fetchBranchHead!(repository, params.branchName, token);
-
-        // Amend semantics: if the last commit on the branch is by the
-        // LocalHero bot in sync mode, replace it instead of stacking.
-        let expectedHeadOid = head.sha;
-        let amended = false;
-        if (params.isSyncMode && this.lastCommitIsLocalHeroBot(head) && head.parentSha) {
-          expectedHeadOid = head.parentSha;
-          amended = true;
-        }
-
         const headlineAndBody = this.splitCommitMessage(params.message);
 
         await this.deps.createSignedCommit!({
           repositoryNameWithOwner: repository,
           branchName: params.branchName,
-          expectedHeadOid,
+          expectedHeadOid: head.sha,
           message: headlineAndBody,
           fileChanges: { additions },
           token
         });
 
-        return amended ? 'amended' : 'new';
+        return 'new';
       } catch (error) {
         lastError = error;
         if (error instanceof StaleHeadError && attempt < maxRetries) {
@@ -594,12 +569,6 @@ jobs:
     }
 
     return additions;
-  },
-
-  lastCommitIsLocalHeroBot(head: BranchHead): boolean {
-    if (!head.authorEmail) return false;
-    const email = head.authorEmail.toLowerCase();
-    return email.includes('localhero');
   },
 
   splitCommitMessage(message: string): { headline: string; body?: string } {

--- a/tests/utils/github-graphql.test.ts
+++ b/tests/utils/github-graphql.test.ts
@@ -148,13 +148,9 @@ describe('createSignedCommit', () => {
 });
 
 describe('fetchBranchHead', () => {
-  it('returns sha, parent sha, and author email', async () => {
+  it('returns the head sha', async () => {
     const mockFetch = jest.fn()
-      .mockImplementationOnce(async () => jsonResponse({ object: { sha: 'a'.repeat(40) } }))
-      .mockImplementationOnce(async () => jsonResponse({
-        parents: [{ sha: 'b'.repeat(40) }],
-        commit: { author: { email: 'developer@example.com' } }
-      }));
+      .mockImplementationOnce(async () => jsonResponse({ object: { sha: 'a'.repeat(40) } }));
 
     const head = await fetchBranchHead(
       'localheroai/test',
@@ -164,8 +160,7 @@ describe('fetchBranchHead', () => {
     );
 
     expect(head.sha).toBe('a'.repeat(40));
-    expect(head.parentSha).toBe('b'.repeat(40));
-    expect(head.authorEmail).toBe('developer@example.com');
+    expect(mockFetch).toHaveBeenCalledTimes(1);
 
     const [refUrl] = mockFetch.mock.calls[0] as [string];
     expect(refUrl).toBe('https://api.github.com/repos/localheroai/test/git/ref/heads/feature');
@@ -179,21 +174,11 @@ describe('fetchBranchHead', () => {
     ).rejects.toBeInstanceOf(GitHubGraphQLError);
   });
 
-  it('handles a commit with no parents (initial commit)', async () => {
-    const mockFetch = jest.fn()
-      .mockImplementationOnce(async () => jsonResponse({ object: { sha: 'a'.repeat(40) } }))
-      .mockImplementationOnce(async () => jsonResponse({
-        parents: [],
-        commit: { author: { email: null } }
-      }));
+  it('throws when the ref response has no sha', async () => {
+    const mockFetch = jest.fn(async () => jsonResponse({ object: {} }));
 
-    const head = await fetchBranchHead(
-      'localheroai/test',
-      'feature',
-      'ghs_token',
-      { fetch: mockFetch as any }
-    );
-
-    expect(head.parentSha).toBeNull();
+    await expect(
+      fetchBranchHead('localheroai/test', 'feature', 'ghs_token', { fetch: mockFetch as any })
+    ).rejects.toThrow(/has no head SHA/);
   });
 });

--- a/tests/utils/github.test.ts
+++ b/tests/utils/github.test.ts
@@ -654,11 +654,7 @@ describe('githubService', () => {
     it('uses GraphQL path when github.signedCommits is true', async () => {
       mockEnv.GITHUB_HEAD_REF = 'feature-branch';
       mockReadFile.mockResolvedValue(Buffer.from('sv:\n  hello: hej'));
-      mockFetchBranchHead.mockResolvedValue({
-        sha: 'a'.repeat(40),
-        parentSha: 'b'.repeat(40),
-        authorEmail: 'developer@example.com'
-      });
+      mockFetchBranchHead.mockResolvedValue({ sha: 'a'.repeat(40) });
       mockCreateSignedCommit.mockResolvedValue({ commitSha: 'c'.repeat(40), commitUrl: 'https://github.com/...' });
 
       await githubService.autoCommitSyncChanges(
@@ -679,39 +675,6 @@ describe('githubService', () => {
       expect(mockConsole.log).toHaveBeenCalledWith('✓ Signed commit created and pushed to GitHub\n');
     });
 
-    it('uses parent SHA as expectedHeadOid when amending LocalHero bot commit', async () => {
-      mockEnv.GITHUB_HEAD_REF = 'feature-branch';
-      mockReadFile.mockResolvedValue(Buffer.from('content'));
-      mockFetchBranchHead.mockResolvedValue({
-        sha: 'a'.repeat(40),
-        parentSha: 'b'.repeat(40),
-        authorEmail: '233842311+localhero-ai[bot]@users.noreply.github.com'
-      });
-      mockCreateSignedCommit.mockResolvedValue({ commitSha: 'c'.repeat(40), commitUrl: 'https://github.com/...' });
-
-      await githubService.autoCommitSyncChanges(['locales/sv.yml']);
-
-      const call = mockCreateSignedCommit.mock.calls[0][0] as any;
-      expect(call.expectedHeadOid).toBe('b'.repeat(40));
-      expect(mockConsole.log).toHaveBeenCalledWith('✓ Commit amended and pushed to GitHub (signed)\n');
-    });
-
-    it('does not amend when the last commit is not by LocalHero bot', async () => {
-      mockEnv.GITHUB_HEAD_REF = 'feature-branch';
-      mockReadFile.mockResolvedValue(Buffer.from('content'));
-      mockFetchBranchHead.mockResolvedValue({
-        sha: 'a'.repeat(40),
-        parentSha: 'b'.repeat(40),
-        authorEmail: 'human@example.com'
-      });
-      mockCreateSignedCommit.mockResolvedValue({ commitSha: 'c'.repeat(40), commitUrl: 'https://github.com/...' });
-
-      await githubService.autoCommitSyncChanges(['locales/sv.yml']);
-
-      const call = mockCreateSignedCommit.mock.calls[0][0] as any;
-      expect(call.expectedHeadOid).toBe('a'.repeat(40));
-    });
-
     it('skips commit when no files exist on disk', async () => {
       mockEnv.GITHUB_HEAD_REF = 'feature-branch';
       mockExistsSync.mockReturnValue(false);
@@ -727,8 +690,8 @@ describe('githubService', () => {
       mockEnv.GITHUB_HEAD_REF = 'feature-branch';
       mockReadFile.mockResolvedValue(Buffer.from('content'));
       mockFetchBranchHead
-        .mockResolvedValueOnce({ sha: 'a'.repeat(40), parentSha: 'b'.repeat(40), authorEmail: null })
-        .mockResolvedValueOnce({ sha: 'd'.repeat(40), parentSha: 'b'.repeat(40), authorEmail: null });
+        .mockResolvedValueOnce({ sha: 'a'.repeat(40) })
+        .mockResolvedValueOnce({ sha: 'd'.repeat(40) });
 
       // Import the error class lazily to avoid top-level imports in test file
       const { StaleHeadError } = await import('../../src/utils/github-graphql.js');
@@ -786,11 +749,7 @@ describe('githubService', () => {
           return Buffer.from('');
         });
         mockReadFile.mockResolvedValue(Buffer.from('content'));
-        mockFetchBranchHead.mockResolvedValue({
-          sha: 'a'.repeat(40),
-          parentSha: 'b'.repeat(40),
-          authorEmail: null
-        });
+        mockFetchBranchHead.mockResolvedValue({ sha: 'a'.repeat(40) });
         mockCreateSignedCommit.mockResolvedValue({ commitSha: 'c'.repeat(40), commitUrl: 'https://github.com/...' });
 
         await githubService.autoCommitChanges('locales/', {
@@ -820,11 +779,7 @@ describe('githubService', () => {
           return Buffer.from('');
         });
         mockReadFile.mockResolvedValue(Buffer.from('content'));
-        mockFetchBranchHead.mockResolvedValue({
-          sha: 'a'.repeat(40),
-          parentSha: 'b'.repeat(40),
-          authorEmail: null
-        });
+        mockFetchBranchHead.mockResolvedValue({ sha: 'a'.repeat(40) });
         mockCreateSignedCommit.mockResolvedValue({ commitSha: 'c'.repeat(40), commitUrl: 'https://github.com/...' });
 
         await githubService.autoCommitChanges('locales/');


### PR DESCRIPTION
The amend path passed parentSha as expectedHeadOid to createCommitOnBranch, which GitHub rejects since expectedHeadOid is a strict HEAD precondition, not a base SHA. Every sync run failed with "Expected branch to point to <parent> but it did not."

Remove some dead code.