### PR TITLE
Preserve untouched bytes when updating YAML files

### DIFF
--- a/src/utils/translation-updater/yaml-handler.ts
+++ b/src/utils/translation-updater/yaml-handler.ts
@@ -1,6 +1,11 @@
 import { promises as fs } from 'fs';
 import yaml from 'yaml';
 import { SPECIAL_CHARS_REGEX, INTERPOLATION, fileExists, tryParseJsonArray } from './common.js';
+import {
+  spliceYamlUpdate,
+  spliceYamlDelete,
+  hasUnsupportedValueShape
+} from './yaml-splicer.js';
 
 interface YamlOptions {
   indent: number;
@@ -8,7 +13,6 @@ interface YamlOptions {
   lineWidth?: number;
 }
 
-// Define more specific types for YAML nodes
 type YamlMap = yaml.YAMLMap;
 type YamlNode = yaml.Node | yaml.YAMLMap | yaml.YAMLSeq | yaml.Scalar;
 type YamlScalar = yaml.Scalar;
@@ -26,7 +30,7 @@ interface UpdateResult {
 }
 
 const NEEDS_QUOTES_REGEX = /[:,%{}[\]|><!&*?-]/;
-const LINE_WIDTH = 0; // Disable line wrapping to preserve original formatting
+const LINE_WIDTH = 0;
 
 function detectYamlOptions(content: string): YamlOptions {
   const lines = content
@@ -73,8 +77,6 @@ function needsQuotes(str: unknown): boolean {
 function shouldForceQuotes(str: unknown): boolean {
   if (typeof str !== 'string') return false;
 
-  // Special case: strings containing quotes but no interpolation
-  // don't need outer quotes
   if (str.includes('"') && !str.includes(INTERPOLATION)) {
     return false;
   }
@@ -154,7 +156,6 @@ async function updateYamlTranslations(
       }
       const nextNode = current.get(key);
       if (!yaml.isMap(nextNode)) {
-        // If the existing node is not a mapping, replace it with an empty mapping
         const newNode = yamlDoc.createNode({}) as YamlMap;
         current.set(key, newNode);
         current = newNode;
@@ -203,18 +204,53 @@ export async function updateYamlFile(
   translations: Record<string, unknown>,
   languageCode: string
 ): Promise<UpdateResult> {
-  const { doc: yamlDoc, created, options } = await createYamlDocument(filePath);
+  const exists = await fileExists(filePath);
 
-  await updateYamlTranslations(yamlDoc, translations, languageCode);
+  if (!exists) {
+    const { doc: yamlDoc, created, options } = await createYamlDocument(filePath);
+    await updateYamlTranslations(yamlDoc, translations, languageCode);
+    await fs.writeFile(filePath, yamlDoc.toString({
+      indent: options.indent,
+      indentSeq: options.indentSeq,
+      lineWidth: LINE_WIDTH
+    }));
+    return {
+      updatedKeys: Object.keys(translations),
+      created
+    };
+  }
 
-  await fs.writeFile(filePath, yamlDoc.toString({
+  const source = await fs.readFile(filePath, 'utf8');
+  const options = detectYamlOptions(source);
+  const doc = yaml.parseDocument(source);
+  clearDuplicateKeyErrors(doc, filePath);
+
+  if (Object.keys(translations).length === 0) {
+    return { updatedKeys: [], created: false };
+  }
+
+  const canSplice = !hasUnsupportedValueShape(translations) && doc.contents && yaml.isMap(doc.contents);
+
+  if (canSplice) {
+    const { output, applied } = spliceYamlUpdate(source, doc, translations, languageCode, options.indent);
+    if (applied) {
+      await fs.writeFile(filePath, output);
+      return {
+        updatedKeys: Object.keys(translations),
+        created: false
+      };
+    }
+  }
+
+  await updateYamlTranslations(doc, translations, languageCode);
+  await fs.writeFile(filePath, doc.toString({
     indent: options.indent,
     indentSeq: options.indentSeq,
     lineWidth: LINE_WIDTH
   }));
   return {
     updatedKeys: Object.keys(translations),
-    created
+    created: false
   };
 }
 
@@ -224,55 +260,14 @@ export async function deleteKeysFromYamlFile(
   languageCode: string
 ): Promise<string[]> {
   try {
-    const content = await fs.readFile(filePath, 'utf8');
-    const yamlDoc = yaml.parseDocument(content);
-    clearDuplicateKeyErrors(yamlDoc, filePath);
-    const contents = yamlDoc.contents as YamlMap | null;
+    const source = await fs.readFile(filePath, 'utf8');
+    const doc = yaml.parseDocument(source);
+    clearDuplicateKeyErrors(doc, filePath);
 
-    if (!contents || !contents.has(languageCode)) {
-      return [];
+    const { output, deletedKeys } = spliceYamlDelete(source, doc, keysToDelete, languageCode);
+    if (deletedKeys.length > 0) {
+      await fs.writeFile(filePath, output);
     }
-
-    const langNode = contents.get(languageCode) as YamlMap;
-    const deletedKeys: string[] = [];
-
-    for (const keyPath of keysToDelete) {
-      const keys = keyPath.split('.');
-      const lastIndex = keys.length - 1;
-      let current = langNode as YamlMap;
-      let parent: YamlMap | null = null;
-      let keyInParent = '';
-      let found = true;
-
-      for (let i = 0; i < lastIndex; i++) {
-        const key = keys[i];
-        if (!current.has(key)) {
-          found = false;
-          break;
-        }
-        parent = current;
-        keyInParent = key;
-        current = current.get(key) as YamlMap;
-      }
-
-      if (found) {
-        const lastKey = keys[lastIndex];
-        if (current.has(lastKey)) {
-          current.delete(lastKey);
-          deletedKeys.push(keyPath);
-          if (parent && current.items.length === 0) {
-            parent.delete(keyInParent);
-          }
-        }
-      }
-    }
-
-    const options = detectYamlOptions(content);
-    await fs.writeFile(filePath, yamlDoc.toString({
-      indent: options.indent,
-      indentSeq: options.indentSeq,
-      lineWidth: LINE_WIDTH
-    }));
     return deletedKeys;
   } catch (error) {
     throw new Error(`Failed to delete keys from YAML file ${filePath}: ${error instanceof Error ? error.message : String(error)}`);

--- a/src/utils/translation-updater/yaml-splicer.ts
+++ b/src/utils/translation-updater/yaml-splicer.ts
@@ -1,0 +1,534 @@
+/**
+ * Byte-range splice writer for YAML files.
+ *
+ * Why this exists: `yaml@2.x` does not preserve original line layout on
+ * round-trip. Plain scalars written across multiple lines (no `>` / `|`
+ * marker) parse with no metadata distinguishing them from single-line plain
+ * scalars, and the emitter decides line layout purely from `lineWidth`. The
+ * maintainer's position is that lossless round-trip is out of scope for the
+ * Document API (eemeli/yaml discussion #510, issue #392 closed as not
+ * planned). For our use case we must not reformat scalars we did not touch,
+ * so we work around this by computing byte-range patches and splicing them
+ * into the original source.
+ */
+import yaml from 'yaml';
+import { tryParseJsonArray } from './common.js';
+
+type YamlMap = yaml.YAMLMap;
+type YamlNode = yaml.Node | yaml.YAMLMap | yaml.YAMLSeq | yaml.Scalar;
+type YamlScalar = yaml.Scalar;
+
+interface Patch {
+  start: number;
+  end: number;
+  text: string;
+}
+
+interface NavigationResult {
+  found: boolean;
+  scalarNode?: YamlScalar;
+  insertionParent?: YamlMap;
+  insertionParentRange?: [number, number, number];
+  remainingPath?: string[];
+  typeCollision?: boolean;
+}
+
+interface ParentContext {
+  column: number;
+  insertionOffset: number;
+}
+
+interface SpliceResult {
+  output: string;
+  applied: boolean;
+}
+
+function getNodeRange(node: unknown): [number, number, number] | null {
+  if (node && typeof node === 'object' && 'range' in node) {
+    const range = (node as { range?: [number, number, number] }).range;
+    if (Array.isArray(range) && range.length === 3) {
+      return range;
+    }
+  }
+  return null;
+}
+
+function columnOfOffset(source: string, offset: number): number {
+  let col = 0;
+  for (let i = offset - 1; i >= 0; i--) {
+    if (source[i] === '\n') break;
+    col++;
+  }
+  return col;
+}
+
+function lineStartColumnOf(source: string, offset: number): number {
+  let lineStart = offset;
+  while (lineStart > 0 && source[lineStart - 1] !== '\n') {
+    lineStart--;
+  }
+  let col = 0;
+  while (lineStart + col < source.length && (source[lineStart + col] === ' ' || source[lineStart + col] === '\t')) {
+    col++;
+  }
+  return col;
+}
+
+const SCALAR_KEY = '__lh_scalar__';
+
+function emitScalarViaLibrary(
+  value: unknown,
+  existingType: string | null,
+  indentUnit: number
+): string {
+  const doc = new yaml.Document();
+  doc.contents = doc.createNode({}) as YamlMap;
+  const rootMap = doc.contents as YamlMap;
+
+  if (typeof value === 'string' && !value.includes('\n') &&
+      (existingType === 'QUOTE_SINGLE' || existingType === 'QUOTE_DOUBLE')) {
+    const scalar = new yaml.Scalar(value);
+    scalar.type = existingType;
+    rootMap.set(SCALAR_KEY, scalar);
+  } else {
+    rootMap.set(SCALAR_KEY, doc.createNode(value));
+  }
+
+  return doc.toString({ indent: indentUnit, lineWidth: 0 });
+}
+
+function indentContinuationLines(text: string, extraIndent: number): string {
+  if (extraIndent === 0) return text;
+  const pad = ' '.repeat(extraIndent);
+  const lines = text.split('\n');
+  return lines
+    .map((line, idx) => (idx === 0 || line.length === 0) ? line : pad + line)
+    .join('\n');
+}
+
+function indentAllLines(text: string, extraIndent: number): string {
+  if (extraIndent === 0) return text;
+  const pad = ' '.repeat(extraIndent);
+  return text
+    .split('\n')
+    .map(line => line.length > 0 ? pad + line : line)
+    .join('\n');
+}
+
+function serializeScalarValue(
+  value: unknown,
+  existingType: string | null,
+  keyColumn: number,
+  indentUnit: number
+): string {
+  const emitted = emitScalarViaLibrary(value, existingType, indentUnit);
+  const prefix = `${SCALAR_KEY}: `;
+  const prefixIdx = emitted.indexOf(prefix);
+  if (prefixIdx < 0) {
+    return JSON.stringify(value);
+  }
+  const valueText = emitted.slice(prefixIdx + prefix.length).replace(/\n$/, '');
+  return indentContinuationLines(valueText, keyColumn);
+}
+
+function navigatePath(doc: yaml.Document, fullPath: string[]): NavigationResult {
+  if (!doc.contents || !yaml.isMap(doc.contents)) {
+    return { found: false };
+  }
+
+  let current: YamlMap = doc.contents as YamlMap;
+  let lastFoundMap: YamlMap = current;
+  let lastFoundRange = getNodeRange(current);
+
+  for (let i = 0; i < fullPath.length; i++) {
+    const key = fullPath[i];
+    if (!current.has(key)) {
+      return {
+        found: false,
+        insertionParent: lastFoundMap,
+        insertionParentRange: lastFoundRange ?? undefined,
+        remainingPath: fullPath.slice(i)
+      };
+    }
+
+    const next = current.get(key, true);
+    const isLast = i === fullPath.length - 1;
+
+    if (isLast) {
+      if (yaml.isScalar(next)) {
+        return { found: true, scalarNode: next };
+      }
+      return {
+        found: false,
+        typeCollision: true
+      };
+    }
+
+    if (!yaml.isMap(next)) {
+      return {
+        found: false,
+        typeCollision: true,
+        insertionParent: lastFoundMap,
+        insertionParentRange: lastFoundRange ?? undefined,
+        remainingPath: fullPath.slice(i)
+      };
+    }
+
+    current = next as YamlMap;
+    lastFoundMap = current;
+    lastFoundRange = getNodeRange(current);
+  }
+
+  return { found: false };
+}
+
+type InsertionTreeLeaf = { __leaf__: true; value: unknown };
+type InsertionTreeNode = Map<string, InsertionTreeNode | InsertionTreeLeaf>;
+
+function isLeaf(node: InsertionTreeNode | InsertionTreeLeaf): node is InsertionTreeLeaf {
+  return (node as InsertionTreeLeaf).__leaf__ === true;
+}
+
+function insertIntoTree(tree: InsertionTreeNode, path: string[], value: unknown): void {
+  if (path.length === 0) return;
+  let current = tree;
+  for (let i = 0; i < path.length - 1; i++) {
+    const key = path[i];
+    const existing = current.get(key);
+    if (!existing || isLeaf(existing)) {
+      const next: InsertionTreeNode = new Map();
+      current.set(key, next);
+      current = next;
+    } else {
+      current = existing;
+    }
+  }
+  current.set(path[path.length - 1], { __leaf__: true, value });
+}
+
+function treeToPlainObject(tree: InsertionTreeNode): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, node] of tree.entries()) {
+    out[key] = isLeaf(node) ? node.value : treeToPlainObject(node);
+  }
+  return out;
+}
+
+function buildInsertionTextFromTree(
+  tree: InsertionTreeNode,
+  parentColumn: number,
+  indentUnit: number
+): string {
+  const plain = treeToPlainObject(tree);
+  const doc = new yaml.Document();
+  doc.contents = doc.createNode(plain);
+  const emitted = doc.toString({ indent: indentUnit, lineWidth: 0 });
+  return indentAllLines(emitted, parentColumn);
+}
+
+function ensureAfterNewline(source: string, offset: number): number {
+  if (offset > 0 && source[offset - 1] === '\n') return offset;
+  let scan = offset;
+  while (scan < source.length && source[scan] !== '\n') scan++;
+  if (scan < source.length) return scan + 1;
+  return source.length;
+}
+
+function findInsertionOffset(
+  source: string,
+  parent: YamlMap,
+  parentRange: [number, number, number] | undefined
+): number {
+  const items = parent.items;
+  if (items.length > 0) {
+    const lastItem = items[items.length - 1];
+    const lastValue = lastItem.value as YamlNode | null;
+    const lastValueRange = lastValue ? getNodeRange(lastValue) : null;
+    if (lastValueRange) return ensureAfterNewline(source, lastValueRange[2]);
+
+    const lastKeyRange = getNodeRange(lastItem.key as YamlNode);
+    if (lastKeyRange) return ensureAfterNewline(source, lastKeyRange[2]);
+  }
+
+  if (parentRange) return ensureAfterNewline(source, parentRange[2]);
+  return source.length;
+}
+
+function resolveParentContext(
+  source: string,
+  parent: YamlMap,
+  parentRange: [number, number, number] | undefined,
+  indentUnit: number
+): ParentContext {
+  let column = 0;
+
+  if (parent.items.length > 0) {
+    const firstChild = parent.items[0];
+    const firstKeyRange = getNodeRange(firstChild.key as YamlNode);
+    column = firstKeyRange ? columnOfOffset(source, firstKeyRange[0]) : indentUnit;
+  } else if (parentRange) {
+    column = columnOfOffset(source, parentRange[0]) + indentUnit;
+  }
+
+  const insertionOffset = findInsertionOffset(source, parent, parentRange);
+  return { column, insertionOffset };
+}
+
+function applyPatches(source: string, patches: Patch[]): string {
+  const sorted = [...patches].sort((a, b) => b.start - a.start);
+  let result = source;
+  for (const patch of sorted) {
+    result = result.slice(0, patch.start) + patch.text + result.slice(patch.end);
+  }
+  return result;
+}
+
+export function hasUnsupportedValueShape(translations: Record<string, unknown>): boolean {
+  for (const value of Object.values(translations)) {
+    if (Array.isArray(value)) return true;
+    if (typeof value === 'string' && tryParseJsonArray(value)) return true;
+  }
+  return false;
+}
+
+export function spliceYamlUpdate(
+  source: string,
+  doc: yaml.Document,
+  translations: Record<string, unknown>,
+  languageCode: string,
+  indentUnit: number
+): SpliceResult {
+  if (!doc.contents || !yaml.isMap(doc.contents)) {
+    return { output: source, applied: false };
+  }
+
+  const patches: Patch[] = [];
+  const insertGroups = new Map<string, {
+    parent: YamlMap;
+    parentRange: [number, number, number] | undefined;
+    tree: InsertionTreeNode;
+  }>();
+
+  for (const [keyPath, value] of Object.entries(translations)) {
+    const pathParts = [languageCode, ...keyPath.split('.')];
+    const nav = navigatePath(doc, pathParts);
+
+    if (nav.typeCollision) {
+      return { output: source, applied: false };
+    }
+
+    if (nav.found && nav.scalarNode) {
+      const existingType = nav.scalarNode.type ?? null;
+      if (existingType === 'BLOCK_LITERAL' || existingType === 'BLOCK_FOLDED') {
+        return { output: source, applied: false };
+      }
+
+      const range = getNodeRange(nav.scalarNode);
+      if (!range) {
+        return { output: source, applied: false };
+      }
+      const keyColumn = lineStartColumnOf(source, range[0]);
+      const serialized = serializeScalarValue(value, existingType, keyColumn, indentUnit);
+      patches.push({ start: range[0], end: range[1], text: serialized });
+      continue;
+    }
+
+    if (!nav.insertionParent || !nav.remainingPath || nav.remainingPath.length === 0) {
+      return { output: source, applied: false };
+    }
+
+    const parentKey = `${(nav.insertionParentRange ?? [0])[0]}`;
+    let group = insertGroups.get(parentKey);
+    if (!group) {
+      group = {
+        parent: nav.insertionParent,
+        parentRange: nav.insertionParentRange,
+        tree: new Map()
+      };
+      insertGroups.set(parentKey, group);
+    }
+    insertIntoTree(group.tree, nav.remainingPath, value);
+  }
+
+  for (const group of insertGroups.values()) {
+    const ctx = resolveParentContext(source, group.parent, group.parentRange, indentUnit);
+    const text = buildInsertionTextFromTree(group.tree, ctx.column, indentUnit);
+    if (text.length > 0) {
+      const insertStart = ctx.insertionOffset;
+      const prefix = insertStart > 0 && source[insertStart - 1] !== '\n' ? '\n' : '';
+      patches.push({ start: insertStart, end: insertStart, text: prefix + text });
+    }
+  }
+
+  return { output: applyPatches(source, patches), applied: true };
+}
+
+interface DeletionTarget {
+  keyPath: string;
+  parentMap: YamlMap;
+  leafKey: string;
+  leafItem: yaml.Pair;
+  ancestorChain: Array<{ map: YamlMap; keyName: string; itemInParent: yaml.Pair }>;
+}
+
+function locateDeletionTarget(
+  doc: yaml.Document,
+  keyPath: string,
+  fullPath: string[]
+): DeletionTarget | null {
+  if (!doc.contents || !yaml.isMap(doc.contents)) return null;
+
+  let current: YamlMap = doc.contents as YamlMap;
+  const ancestorChain: Array<{ map: YamlMap; keyName: string; itemInParent: yaml.Pair }> = [];
+
+  for (let i = 0; i < fullPath.length - 1; i++) {
+    const key = fullPath[i];
+    const itemInParent = current.items.find(it => {
+      const k = it.key as { value?: unknown } | null;
+      return k && k.value === key;
+    });
+    if (!itemInParent) return null;
+    const next = itemInParent.value;
+    if (!yaml.isMap(next)) return null;
+    ancestorChain.push({ map: current, keyName: key, itemInParent });
+    current = next as YamlMap;
+  }
+
+  const leafKey = fullPath[fullPath.length - 1];
+  const leafItem = current.items.find(it => {
+    const k = it.key as { value?: unknown } | null;
+    return k && k.value === leafKey;
+  });
+  if (!leafItem) return null;
+
+  return { keyPath, parentMap: current, leafKey, leafItem, ancestorChain };
+}
+
+function computeDeletionRange(
+  source: string,
+  keyRange: [number, number, number],
+  nodeEnd: number
+): { start: number; end: number } {
+  let start = keyRange[0];
+  while (start > 0 && (source[start - 1] === ' ' || source[start - 1] === '\t')) {
+    start--;
+  }
+  let end = nodeEnd;
+  if (end > 0 && source[end - 1] !== '\n') {
+    while (end < source.length && (source[end] === ' ' || source[end] === '\t')) {
+      end++;
+    }
+    if (end < source.length && source[end] === '\n') {
+      end++;
+    }
+  }
+  return { start, end };
+}
+
+function patchForItem(source: string, item: yaml.Pair): Patch | null {
+  const keyRange = getNodeRange(item.key as YamlNode);
+  if (!keyRange) return null;
+  const valueRange = item.value ? getNodeRange(item.value as YamlNode) : null;
+  const nodeEnd = valueRange ? valueRange[2] : keyRange[2];
+  const { start, end } = computeDeletionRange(source, keyRange, nodeEnd);
+  return { start, end, text: '' };
+}
+
+export interface SpliceDeleteResult {
+  output: string;
+  deletedKeys: string[];
+}
+
+export function spliceYamlDelete(
+  source: string,
+  doc: yaml.Document,
+  keysToDelete: string[],
+  languageCode: string
+): SpliceDeleteResult {
+  if (!doc.contents || !yaml.isMap(doc.contents) || !(doc.contents as YamlMap).has(languageCode)) {
+    return { output: source, deletedKeys: [] };
+  }
+
+  const targets: DeletionTarget[] = [];
+  for (const keyPath of keysToDelete) {
+    const fullPath = [languageCode, ...keyPath.split('.')];
+    const target = locateDeletionTarget(doc, keyPath, fullPath);
+    if (target) targets.push(target);
+  }
+
+  if (targets.length === 0) {
+    return { output: source, deletedKeys: [] };
+  }
+
+  const deletionsByParent = new Map<YamlMap, Set<string>>();
+  for (const target of targets) {
+    let set = deletionsByParent.get(target.parentMap);
+    if (!set) {
+      set = new Set<string>();
+      deletionsByParent.set(target.parentMap, set);
+    }
+    set.add(target.leafKey);
+  }
+
+  const collapsedMaps = new Set<YamlMap>();
+  for (const target of targets) {
+    const parentSet = deletionsByParent.get(target.parentMap)!;
+    const parentAllDeleted = target.parentMap.items.every(it => {
+      const k = it.key as { value?: unknown } | null;
+      return k && parentSet.has(k.value as string);
+    });
+    if (!parentAllDeleted) continue;
+
+    collapsedMaps.add(target.parentMap);
+
+    for (let i = target.ancestorChain.length - 1; i >= 0; i--) {
+      const ancestor = target.ancestorChain[i];
+      const childMap = i === target.ancestorChain.length - 1
+        ? target.parentMap
+        : target.ancestorChain[i + 1].map;
+      if (!collapsedMaps.has(childMap)) break;
+
+      const ancestorMap = ancestor.map;
+      const onlyOneChild = ancestorMap.items.length === 1;
+      const matches = ancestorMap.items.every(it => {
+        const k = it.key as { value?: unknown } | null;
+        return k && k.value === ancestor.keyName;
+      });
+      if (onlyOneChild && matches) {
+        collapsedMaps.add(ancestorMap);
+      } else {
+        break;
+      }
+    }
+  }
+
+  const patches: Patch[] = [];
+  const emittedItems = new Set<yaml.Pair>();
+
+  for (const target of targets) {
+    let outermostCollapsedItem: yaml.Pair | null = null;
+    for (let i = target.ancestorChain.length - 1; i >= 0; i--) {
+      const ancestor = target.ancestorChain[i];
+      const childMap = i === target.ancestorChain.length - 1
+        ? target.parentMap
+        : target.ancestorChain[i + 1].map;
+      if (collapsedMaps.has(childMap)) {
+        outermostCollapsedItem = ancestor.itemInParent;
+      } else {
+        break;
+      }
+    }
+
+    const itemToEmit = outermostCollapsedItem ?? target.leafItem;
+    if (emittedItems.has(itemToEmit)) continue;
+
+    const patch = patchForItem(source, itemToEmit);
+    if (patch) {
+      patches.push(patch);
+      emittedItems.add(itemToEmit);
+    }
+  }
+
+  const deletedKeys = targets.map(t => t.keyPath);
+  return { output: applyPatches(source, patches), deletedKeys };
+}

--- a/tests/utils/git-changes.test.js
+++ b/tests/utils/git-changes.test.js
@@ -165,7 +165,7 @@ describe('git-changes module (object-based diff)', () => {
 
   // Regression: comparing against the base branch tip instead of the merge-base
   // attributed develop's progress to the user's branch and triggered spurious
-  // translations on long-lived branches (Qasa 2026-04-27).
+  // translations on long-lived branches.
   describe('merge-base comparison', () => {
     it('compares against merge-base SHA instead of base ref tip', () => {
       const oldContent = JSON.stringify({ user: { other: 'Other' } });

--- a/tests/utils/translation-updater.test.js
+++ b/tests/utils/translation-updater.test.js
@@ -2,6 +2,7 @@ import { jest } from '@jest/globals';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
+import yaml from 'yaml';
 import { updateTranslationFile, deleteKeysFromTranslationFile } from '../../src/utils/translation-updater/index.js';
 
 describe('translation-updater', () => {
@@ -505,6 +506,412 @@ en:
         expect(content).toContain('First line');
         expect(content).toContain('Second line');
         expect(content).toContain('content: Regular content');
+      });
+    });
+
+    describe('multi-line plain scalar preservation', () => {
+      it('does not reformat multi-line plain scalars in untouched locales when adding a key to one locale', async () => {
+        const filePath = path.join(tempDir, 'booking_reminder.yml');
+        const initialContent = `---
+en:
+  subject: Before your viewing with %{tenant_name}
+  headline: Before your viewing
+  description:
+    A quick note ahead of the viewing at %{address} with %{tenant_name}.
+    Here are the details you'll need.
+  note:
+    Please arrive a few minutes early. If anything changes, let us know
+    via the conversation thread linked below.
+  button: Open conversation
+sv:
+  subject: Inför visningen med %{tenant_name}
+  headline: Inför visningen
+  description:
+    En liten påminnelse inför visningen på %{address} med %{tenant_name}.
+    Här är detaljerna du behöver.
+  note:
+    Var där några minuter i förväg. Om något ändras, hör av dig
+    via konversationen länkad nedan.
+  button: Öppna konversation
+nb:
+  subject: Før visningen med %{tenant_name}
+  headline: Før visningen
+  description:
+    En liten påminnelse før visningen på %{address} med %{tenant_name}.
+    Her er detaljene du trenger.
+  note:
+    Vær der noen minutter i forveien. Hvis noe endrer seg, gi oss beskjed
+    via samtalen lenket nedenfor.
+  button: Åpne samtale
+`;
+        fs.writeFileSync(filePath, initialContent);
+
+        await updateTranslationFile(filePath, {
+          'subject': 'Ennen näyttöä vuokralaisen %{tenant_name} kanssa'
+        }, 'fi');
+
+        const updated = fs.readFileSync(filePath, 'utf8');
+
+        const enBlock = updated.split(/^sv:/m)[0];
+
+        expect(enBlock).toContain('  description:\n');
+        expect(enBlock).toContain('    A quick note ahead of the viewing');
+        expect(enBlock).toContain('    Here are the details');
+
+        expect(enBlock).toContain('  note:\n');
+        expect(enBlock).toContain('    Please arrive a few minutes early');
+        expect(enBlock).toContain('    via the conversation thread linked below');
+
+        const enDescriptionAsOneLine = /  description: A quick note ahead of the viewing at %\{address\} with %\{tenant_name\}\. Here are the details/;
+        expect(updated).not.toMatch(enDescriptionAsOneLine);
+
+        expect(updated).toContain('fi:');
+        expect(updated).toMatch(/subject:\s+"?Ennen näyttöä vuokralaisen %\{tenant_name\} kanssa"?/);
+      });
+
+      it('does not collapse a multi-line plain scalar that lives in the SAME locale as the key being added', async () => {
+        const filePath = path.join(tempDir, 'tenant_ended.yml');
+        const initialContent = `---
+en:
+  subject: End of lease
+  description:
+    Your rental period for %{home_address} has now ended. If you have paid
+    us a security deposit, we will repay you the money as soon as we have received
+    approval from your landlord.
+  button: Add bank account details
+`;
+        fs.writeFileSync(filePath, initialContent);
+
+        await updateTranslationFile(filePath, {
+          'headline': 'End of lease'
+        }, 'en');
+
+        const updated = fs.readFileSync(filePath, 'utf8');
+
+        expect(updated).toContain('  description:\n');
+        expect(updated).toContain('    Your rental period for %{home_address} has now ended');
+        expect(updated).toContain('    us a security deposit');
+        expect(updated).toContain('    approval from your landlord');
+
+        const descriptionAsOneLine = /  description: Your rental period for %\{home_address\} has now ended\. If you have paid us a security deposit/;
+        expect(updated).not.toMatch(descriptionAsOneLine);
+
+        expect(updated).toContain('headline: End of lease');
+      });
+
+      it('does not reformat ANY untouched multi-line plain scalars when adding one new key', async () => {
+        const filePath = path.join(tempDir, 'multi.yml');
+        const initialContent = `---
+en:
+  one:
+    Multi-line plain one continues
+    onto a second line here.
+  two:
+    Multi-line plain two also continues
+    onto a second line here.
+  three:
+    Multi-line plain three continues
+    onto a second line here too.
+  short: short value
+`;
+        fs.writeFileSync(filePath, initialContent);
+
+        await updateTranslationFile(filePath, {
+          'four': 'a brand new key value'
+        }, 'en');
+
+        const updated = fs.readFileSync(filePath, 'utf8');
+
+        const originalLines = initialContent.split('\n').filter(l => l.trim());
+        const updatedLines = updated.split('\n').filter(l => l.trim());
+
+        for (const original of originalLines) {
+          expect(updatedLines).toContain(original);
+        }
+
+        expect(updated).toContain('four: a brand new key value');
+      });
+
+      it('produces byte-identical output when no changes are requested', async () => {
+        const filePath = path.join(tempDir, 'roundtrip.yml');
+        const initialContent = `---
+en:
+  subject: Before your viewing with %{tenant_name}
+  description:
+    A quick note ahead of the viewing at %{address}.
+    Here are the details you'll need.
+  body: |
+    Line one of literal block.
+    Line two of literal block.
+  folded: >
+    Folded scalar that spans
+    multiple lines.
+  quoted_double: "Hello, %{name}!"
+  quoted_single: 'It''s a test'
+  nested:
+    deeply:
+      value: leaf
+  array:
+    - one
+    - two
+sv:
+  subject: Inför visningen
+  body: |
+    Rad ett.
+    Rad två.
+`;
+        fs.writeFileSync(filePath, initialContent);
+
+        await updateTranslationFile(filePath, {}, 'en');
+
+        const after = fs.readFileSync(filePath, 'utf8');
+        expect(after).toBe(initialContent);
+      });
+
+      it('handles deeply nested key insertion', async () => {
+        const filePath = path.join(tempDir, 'deep.yml');
+        const initialContent = `---
+en:
+  app: TaskFlow
+`;
+        fs.writeFileSync(filePath, initialContent);
+
+        await updateTranslationFile(filePath, {
+          'section.subsection.deeply.nested.key': 'deep value'
+        }, 'en');
+
+        const updated = fs.readFileSync(filePath, 'utf8');
+
+        expect(updated).toContain('  app: TaskFlow');
+        expect(updated).toMatch(/  section:\n {4}subsection:\n {6}deeply:\n {8}nested:\n {10}key: deep value/);
+      });
+
+      it('preserves a file without a trailing newline', async () => {
+        const filePath = path.join(tempDir, 'no-trailing.yml');
+        const initialContent = `en:\n  subject: Hello`;
+        fs.writeFileSync(filePath, initialContent);
+
+        await updateTranslationFile(filePath, {
+          'greeting': 'Welcome'
+        }, 'en');
+
+        const updated = fs.readFileSync(filePath, 'utf8');
+
+        expect(updated).toContain('  subject: Hello');
+        expect(updated).toContain('  greeting: Welcome');
+      });
+
+      it('overwriting a map-valued key with a scalar falls back without corrupting the file', async () => {
+        const filePath = path.join(tempDir, 'collision.yml');
+        const initialContent = `en:
+  buttons:
+    submit: Submit
+  other: stays
+`;
+        fs.writeFileSync(filePath, initialContent);
+
+        await updateTranslationFile(filePath, { buttons: 'Press me' }, 'en');
+
+        const updated = fs.readFileSync(filePath, 'utf8');
+
+        const buttonsOccurrences = (updated.match(/^ {2}buttons:/gm) || []).length;
+        expect(buttonsOccurrences).toBe(1);
+        expect(updated).toContain('other: stays');
+      });
+
+      it('replacing an existing block literal scalar produces valid YAML', async () => {
+        const filePath = path.join(tempDir, 'block-replace.yml');
+        const initialContent = `en:
+  description: |
+    Line one
+    Line two
+  other: stays
+`;
+        fs.writeFileSync(filePath, initialContent);
+
+        await updateTranslationFile(filePath, {
+          description: 'New line one\nNew line two'
+        }, 'en');
+
+        const updated = fs.readFileSync(filePath, 'utf8');
+
+        expect(updated).toMatch(/description:\s*\|/);
+        expect(updated).toContain('New line one');
+        expect(updated).toContain('New line two');
+        expect(updated).toContain('other: stays');
+
+        const parsed = yaml.parse(updated);
+        expect(parsed.en.description).toContain('New line one');
+        expect(parsed.en.description).toContain('New line two');
+        expect(parsed.en.other).toBe('stays');
+      });
+
+      it('inserting multiple keys under a missing locale produces a single merged block', async () => {
+        const filePath = path.join(tempDir, 'new-locale.yml');
+        const initialContent = `en:
+  subject: Hello
+  headline: Title
+`;
+        fs.writeFileSync(filePath, initialContent);
+
+        await updateTranslationFile(filePath, {
+          subject: 'Hej',
+          headline: 'Rubrik'
+        }, 'sv');
+
+        const updated = fs.readFileSync(filePath, 'utf8');
+        const svBlockCount = (updated.match(/^sv:/gm) || []).length;
+        expect(svBlockCount).toBe(1);
+
+        const parsed = yaml.parse(updated);
+        expect(parsed.sv.subject).toBe('Hej');
+        expect(parsed.sv.headline).toBe('Rubrik');
+      });
+
+      it('inserting multiple keys under a missing nested section produces a single merged block', async () => {
+        const filePath = path.join(tempDir, 'new-section.yml');
+        const initialContent = `en:
+  existing: ok
+`;
+        fs.writeFileSync(filePath, initialContent);
+
+        await updateTranslationFile(filePath, {
+          'section.first': 'A',
+          'section.second': 'B'
+        }, 'en');
+
+        const updated = fs.readFileSync(filePath, 'utf8');
+        const sectionBlockCount = (updated.match(/^ {2}section:/gm) || []).length;
+        expect(sectionBlockCount).toBe(1);
+
+        const parsed = yaml.parse(updated);
+        expect(parsed.en.section.first).toBe('A');
+        expect(parsed.en.section.second).toBe('B');
+      });
+
+      it('quotes string values that YAML would otherwise re-parse as non-strings', async () => {
+        const filePath = path.join(tempDir, 'type-safe.yml');
+        const initialContent = `en:
+  existing: ok
+`;
+        fs.writeFileSync(filePath, initialContent);
+
+        await updateTranslationFile(filePath, {
+          numeric: '123',
+          truthy: 'true',
+          nully: 'null',
+          empty: ''
+        }, 'en');
+
+        const updated = fs.readFileSync(filePath, 'utf8');
+        const parsed = yaml.parse(updated);
+        expect(parsed.en.numeric).toBe('123');
+        expect(parsed.en.truthy).toBe('true');
+        expect(parsed.en.nully).toBe('null');
+        expect(parsed.en.empty).toBe('');
+      });
+
+      it('updating an existing key with a string that looks numeric preserves string type', async () => {
+        const filePath = path.join(tempDir, 'numeric-update.yml');
+        const initialContent = `en:
+  zip_code: "12345"
+`;
+        fs.writeFileSync(filePath, initialContent);
+
+        await updateTranslationFile(filePath, { zip_code: '99999' }, 'en');
+
+        const updated = fs.readFileSync(filePath, 'utf8');
+        const parsed = yaml.parse(updated);
+        expect(parsed.en.zip_code).toBe('99999');
+        expect(typeof parsed.en.zip_code).toBe('string');
+      });
+
+      it('replacing a single-line scalar with a multi-line value indents continuation lines correctly', async () => {
+        const filePath = path.join(tempDir, 'multiline-indent.yml');
+        const initialContent = `en:
+  desc: short
+  other: keep
+`;
+        fs.writeFileSync(filePath, initialContent);
+
+        await updateTranslationFile(filePath, {
+          desc: 'long\nmulti\nline'
+        }, 'en');
+
+        const updated = fs.readFileSync(filePath, 'utf8');
+        const parsed = yaml.parse(updated);
+        expect(parsed.en.desc).toBe('long\nmulti\nline');
+        expect(parsed.en.other).toBe('keep');
+
+        const lines = updated.split('\n');
+        const continuationLines = lines.filter(l => /^ +(long|multi|line)$/.test(l));
+        expect(continuationLines.length).toBe(3);
+        for (const line of continuationLines) {
+          const leadingSpaces = line.match(/^ +/)[0].length;
+          expect(leadingSpaces).toBe(4);
+        }
+      });
+    });
+
+    describe('multi-key deletion safety', () => {
+      it('deleting all children of a nested map removes the parent without losing siblings', async () => {
+        const filePath = path.join(tempDir, 'multi-delete.yml');
+        const initialContent = `en:
+  section:
+    first: A
+    second: B
+  keep: ok
+`;
+        fs.writeFileSync(filePath, initialContent);
+
+        await deleteKeysFromTranslationFile(filePath, ['section.first', 'section.second'], 'en');
+
+        const updated = fs.readFileSync(filePath, 'utf8');
+        const parsed = yaml.parse(updated);
+
+        expect(parsed.en.section).toBeUndefined();
+        expect(parsed.en.keep).toBe('ok');
+      });
+
+      it('deleting two siblings of a nested map preserves remaining children', async () => {
+        const filePath = path.join(tempDir, 'partial-delete.yml');
+        const initialContent = `en:
+  section:
+    first: A
+    second: B
+    survivor: keep
+`;
+        fs.writeFileSync(filePath, initialContent);
+
+        await deleteKeysFromTranslationFile(filePath, ['section.first', 'section.second'], 'en');
+
+        const updated = fs.readFileSync(filePath, 'utf8');
+        const parsed = yaml.parse(updated);
+
+        expect(parsed.en.section.first).toBeUndefined();
+        expect(parsed.en.section.second).toBeUndefined();
+        expect(parsed.en.section.survivor).toBe('keep');
+      });
+
+      it('deleting non-adjacent sibling keys preserves keys between them', async () => {
+        const filePath = path.join(tempDir, 'non-adjacent-delete.yml');
+        const initialContent = `en:
+  a: 1
+  b: 2
+  c: 3
+  d: 4
+`;
+        fs.writeFileSync(filePath, initialContent);
+
+        await deleteKeysFromTranslationFile(filePath, ['a', 'c'], 'en');
+
+        const updated = fs.readFileSync(filePath, 'utf8');
+        const parsed = yaml.parse(updated);
+
+        expect(parsed.en.a).toBeUndefined();
+        expect(parsed.en.b).toBe(2);
+        expect(parsed.en.c).toBeUndefined();
+        expect(parsed.en.d).toBe(4);
       });
     });
 

--- a/tests/utils/yaml-multi-language.test.ts
+++ b/tests/utils/yaml-multi-language.test.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import os from 'os';
 import { updateTranslationFile } from '../../src/utils/translation-updater/index.js';
 
-const QASA_SHAPE = `---
+const MULTI_LANG_SHAPE = `---
 en:
   headline: ''
   subject: Invitation
@@ -35,14 +35,14 @@ function extractBlock(raw: string, locale: string): string[] {
   return block;
 }
 
-describe('YAML multi-language sequential writes preserve Qasa-shape formatting', () => {
+describe('YAML multi-language sequential writes preserve multi-language email-template-shape formatting', () => {
   let tempDir: string;
   let multiLangPath: string;
 
   beforeEach(async () => {
     tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'localhero-yaml-multi-'));
     multiLangPath = path.join(tempDir, 'invite.i18n.yml');
-    await fs.writeFile(multiLangPath, QASA_SHAPE, 'utf8');
+    await fs.writeFile(multiLangPath, MULTI_LANG_SHAPE, 'utf8');
   });
 
   afterEach(async () => {
@@ -66,12 +66,12 @@ describe('YAML multi-language sequential writes preserve Qasa-shape formatting',
       .map(l => l.replace(':', ''));
     expect(topLevelLocales).toEqual(['en', 'sv', 'nb', 'fi']);
 
-    const originalLines = QASA_SHAPE.split('\n');
+    const originalLines = MULTI_LANG_SHAPE.split('\n');
     const originalLineCount = originalLines.filter(l => l.length > 0).length;
     const actualLineCount = lines.filter(l => l.length > 0).length;
     expect(actualLineCount).toBe(originalLineCount + 3);
 
-    const enBlockBefore = extractBlock(QASA_SHAPE, 'en');
+    const enBlockBefore = extractBlock(MULTI_LANG_SHAPE, 'en');
     const enBlockAfter = extractBlock(raw, 'en');
     expect(enBlockAfter).toEqual(enBlockBefore);
 


### PR DESCRIPTION
Existing files are now updated via a byte-range splice writer rather than re-emitting the parsed document. Untouched scalars survive verbatim, including multi-line plain scalars that previously got collapsed onto a single line on every save.

The library's document emitter still handles greenfield files and unsupported value shapes (arrays). Block-literal value replacements also fall back.