### PR TITLE
Custom locale support: scanning, init declarations, custom_languages payload (#405)

### DIFF
--- a/src/api/projects.ts
+++ b/src/api/projects.ts
@@ -1,5 +1,6 @@
 import { getApiKey } from '../utils/auth.js';
 import { apiRequest } from './client.js';
+import { CustomLocale } from '../types/index.js';
 
 /**
  * Project details returned from the API
@@ -31,6 +32,8 @@ export interface CreateProjectParams {
   name: string;
   sourceLocale: string;
   targetLocales: string[];
+  /** Declarations for non-standard locale codes, validated by the backend */
+  customLocales?: CustomLocale[];
 }
 
 /**
@@ -46,7 +49,14 @@ export async function createProject(data: CreateProjectParams): Promise<ProjectD
       project: {
         name: data.name,
         source_language: data.sourceLocale,
-        target_languages: data.targetLocales
+        target_languages: data.targetLocales,
+        ...(data.customLocales?.length && {
+          custom_languages: data.customLocales.map((locale) => ({
+            code: locale.code,
+            name: locale.name,
+            base_language: locale.baseLanguage
+          }))
+        })
       }
     },
     apiKey

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -8,8 +8,8 @@ import { checkAuth } from '../utils/auth.js';
 import { login } from './login.js';
 import { importService, ImportResult } from '../utils/import-service.js';
 import { createGitHubActionFile, workflowExists } from '../utils/github.js';
-import { directoryExists, findFirstExistingPath, getDirectoryContents, DirectoryContents } from '../utils/files.js';
-import { ProjectConfig as BaseProjectConfig } from '../types/index.js';
+import { directoryExists, findFirstExistingPath, getDirectoryContents, isValidLocale, DirectoryContents } from '../utils/files.js';
+import { ProjectConfig as BaseProjectConfig, CustomLocale } from '../types/index.js';
 import { verifyApiKey } from '../api/auth.js';
 import { Spinner } from '../utils/spinner.js';
 
@@ -144,12 +144,15 @@ export class MissingFlagsError extends Error {
   }
 }
 
+const REGION_SHAPED_LOCALE = /^[a-zA-Z]{2,3}[_-][a-zA-Z]{2}$/;
+
 interface RawInitInputs {
   mode: 'new' | 'existing';
   existingProject?: ProjectDetails;
   projectName?: string;
   sourceLocale: string;
   outputLocales: string[];
+  customLocales?: CustomLocale[];
   translationPath: string;
   filePattern: string;
   ignorePaths: string[];
@@ -726,7 +729,7 @@ async function handleNewProjectSetup(
 
   const finalized = await finalizeProjectAndBuildConfig(inputs, projectDefaults, projectApi, console);
   if (!finalized) {
-    return;
+    throw new Error('Project creation failed');
   }
   const { config, newProject, url } = finalized;
 
@@ -808,6 +811,7 @@ async function collectInputsInteractive(
   let projectName: string | undefined;
   let sourceLocale: string;
   let outputLocales: string[];
+  const customLocales: CustomLocale[] = [];
 
   if (!existingProject) {
     sourceLocale = await promptService.input({
@@ -822,6 +826,25 @@ async function collectInputsInteractive(
     }));
 
     outputLocales = filterSourceFromTargets(sourceLocale, rawOutputLocales, console);
+
+    const nonStandardLocales = outputLocales.filter(
+      (locale) => !isValidLocale(locale) && !REGION_SHAPED_LOCALE.test(locale)
+    );
+    for (const code of nonStandardLocales) {
+      console.log(chalk.yellow(`\n'${code}' is not a standard locale code — the details below define it as a custom locale.`));
+      const name = await promptService.input({
+        message: `Display name for '${code}' (shown in Localhero, e.g. "Easy Japanese"):`,
+        default: code
+      });
+      let baseLanguage = '';
+      while (!/^[a-z]{2}$/.test(baseLanguage)) {
+        baseLanguage = (await promptService.input({
+          message: `Base language for '${code}' (a 2-letter code, like "ja" for Japanese):`,
+          default: code.split(/[_-]/)[0]
+        })).trim().toLowerCase();
+      }
+      customLocales.push({ code, name, baseLanguage });
+    }
 
     projectName = await promptService.input({
       message: 'Project name:',
@@ -873,6 +896,7 @@ async function collectInputsInteractive(
     projectName,
     sourceLocale,
     outputLocales,
+    ...(customLocales.length > 0 && { customLocales }),
     translationPath,
     filePattern,
     ignorePaths: parseCsv(ignorePathsRaw)
@@ -948,6 +972,16 @@ async function collectInputsFromFlags(
     throw new Error('After removing the source locale, no target locales remain');
   }
 
+  const nonStandard = outputLocales.filter(
+    (locale) => !isValidLocale(locale) && !REGION_SHAPED_LOCALE.test(locale)
+  );
+  if (nonStandard.length > 0) {
+    throw new Error(
+      `Non-standard locale codes need custom-locale details: ${nonStandard.join(', ')}. ` +
+      'Run `localhero init` interactively to declare them.'
+    );
+  }
+
   return {
     mode: 'new',
     projectName: options.projectName ?? path.basename(process.cwd()),
@@ -974,7 +1008,8 @@ async function finalizeProjectAndBuildConfig(
       const created = await projectService.createProject({
         name: inputs.projectName as string,
         sourceLocale: inputs.sourceLocale,
-        targetLocales: inputs.outputLocales
+        targetLocales: inputs.outputLocales,
+        ...(inputs.customLocales?.length && { customLocales: inputs.customLocales })
       });
       projectId = created.id;
       projectUrl = created.url;
@@ -996,6 +1031,7 @@ async function finalizeProjectAndBuildConfig(
     projectId,
     sourceLocale: inputs.sourceLocale,
     outputLocales: inputs.outputLocales,
+    ...(inputs.customLocales?.length && { customLocales: inputs.customLocales }),
     translationFiles: {
       paths: inputs.translationPath ? [inputs.translationPath] : [],
       pattern: inputs.filePattern || '**/*.{json,yml,yaml,po}',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -38,6 +38,19 @@ export interface TranslationWithMetadata {
 }
 
 /**
+ * A customer-declared non-standard locale (e.g. ja_easy).
+ * The backend validates baseLanguage and creates the locale; the CLI only collects and forwards.
+ */
+export interface CustomLocale {
+  /** Literal locale code as used in filenames/config (e.g. 'ja_easy') */
+  code: string;
+  /** Human-readable name (e.g. 'Easy Japanese') */
+  name: string;
+  /** ISO-639-1 base language driving plurals/flag (e.g. 'ja') */
+  baseLanguage: string;
+}
+
+/**
  * Project configuration interface
  *
  * This is the single source of truth for project configuration
@@ -54,6 +67,9 @@ export interface ProjectConfig {
 
   /** Target locale codes (e.g., ['fr', 'de', 'es']) */
   outputLocales: string[];
+
+  /** Declared custom locales — whitelists non-standard codes through backend validation */
+  customLocales?: CustomLocale[];
 
   /** Translation files configuration */
   translationFiles: TranslationFileConfig;

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -184,6 +184,13 @@ export const configService: ConfigService = {
 
     validateIgnoreKeys(config.translationFiles?.ignoreKeys);
 
+    const missingFromOutput = (config.customLocales ?? [])
+      .map((locale) => locale.code)
+      .filter((code) => !config.outputLocales.includes(code));
+    if (missingFromOutput.length > 0) {
+      throw new Error(`customLocales codes must also be listed in outputLocales: ${missingFromOutput.join(', ')}`);
+    }
+
     return true;
   },
 

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -54,32 +54,37 @@ const DEFAULT_LOCALE_REGEX = '(?:^|[._-])([a-z]{2}(?:-[A-Z]{2})?)\\.(?:yml|yaml|
 export function extractLocaleFromPath(filePath: string, localeRegex?: string, knownLocales: string[] = []): string {
   const effectiveLocaleRegex = localeRegex ?? DEFAULT_LOCALE_REGEX;
   if (knownLocales && knownLocales.length > 0) {
+    const matchKnownLocale = (candidate: string): string | undefined =>
+      knownLocales.find((kl) => kl === candidate) ??
+      knownLocales.find((kl) => kl && candidate.toLowerCase() === kl.toLowerCase());
+
     const basenameOriginal = path.basename(filePath, path.extname(filePath));
-    const isBasenameAKnownLocale = knownLocales.some(
-      (kl) => kl && basenameOriginal.toLowerCase() === kl.toLowerCase()
-    );
-    if (isBasenameAKnownLocale) {
-      if (isValidLocale(basenameOriginal)) {
-        if (basenameOriginal.length === 2) {
-          return basenameOriginal.toLowerCase();
-        }
-        return basenameOriginal;
+    const basenameMatch = matchKnownLocale(basenameOriginal);
+    if (basenameMatch) {
+      return basenameMatch;
+    }
+
+    for (const part of filePath.split(path.sep)) {
+      const partMatch = matchKnownLocale(part);
+      if (partMatch) {
+        return partMatch;
       }
     }
 
-    const originalPathParts = filePath.split(path.sep);
-    for (const part of originalPathParts) {
-      const isPartAKnownLocale = knownLocales.some(
-        (kl) => kl && part.toLowerCase() === kl.toLowerCase()
-      );
-      if (isPartAKnownLocale) {
-        if (isValidLocale(part)) {
-          if (part.length === 2) {
-            return part.toLowerCase();
-          }
-          return part;
-        }
+    const lastSegment = basenameOriginal.split('.').pop();
+    if (lastSegment && lastSegment !== basenameOriginal) {
+      const segmentMatch = matchKnownLocale(lastSegment);
+      if (segmentMatch) {
+        return segmentMatch;
       }
+    }
+
+    const basenameLower = basenameOriginal.toLowerCase();
+    const suffixMatch = knownLocales.find(
+      (kl) => kl && (basenameLower.endsWith(`_${kl.toLowerCase()}`) || basenameLower.endsWith(`-${kl.toLowerCase()}`))
+    );
+    if (suffixMatch) {
+      return suffixMatch;
     }
   }
 

--- a/src/utils/sync-service.ts
+++ b/src/utils/sync-service.ts
@@ -3,6 +3,7 @@ import { configService } from './config.js';
 import { getUpdates, GetUpdatesParams } from '../api/translations.js';
 import { updateTranslationFile, deleteKeysFromTranslationFile } from './translation-updater/index.js';
 import { findTranslationFiles } from './files.js';
+import { localeCodesMatch } from './translation-processor.js';
 import { getCurrentBranch } from './git.js';
 import path from 'path';
 import { TranslationFile, TranslationFilesResult, TranslationWithMetadata } from '../types/index.js';
@@ -170,6 +171,11 @@ export const syncService: SyncService = {
       sourceFilesByPath[dirName] = sourceFile.path;
     }
 
+    // The backend reports canonical codes (zh-CN); files use the config spelling (zh_cn)
+    const configLocales = [config.sourceLocale, ...(config.outputLocales ?? [])];
+    const toConfigLocale = (code: string): string =>
+      configLocales.find((locale) => localeCodesMatch(locale, code)) ?? code;
+
     for (const file of updates.updates.files || []) {
       // Find the corresponding source file
       const dirName = path.dirname(file.path);
@@ -205,7 +211,7 @@ export const syncService: SyncService = {
         }
 
         try {
-          const updateResult = await updateTranslationFile(file.path, translations, lang.code, sourceFilePath, config.sourceLocale, config);
+          const updateResult = await updateTranslationFile(file.path, translations, toConfigLocale(lang.code), sourceFilePath, config.sourceLocale, config);
           totalUpdates += updateResult.updatedKeys.length;
         } catch (error: any) {
           console.error(chalk.yellow(`⚠️  Failed to update ${file.path}: ${error.message}`));

--- a/src/utils/translation-processor.ts
+++ b/src/utils/translation-processor.ts
@@ -148,6 +148,28 @@ function createJobSourceMapping(
   return jobSourceMapping;
 }
 
+export function localeCodesMatch(a: string, b: string): boolean {
+  return a.toLowerCase().replace(/_/g, '-') === b.toLowerCase().replace(/_/g, '-');
+}
+
+function findMissingEntryKey(
+  missingByLocale: MissingByLocale,
+  languageCode: string,
+  sourceFilePath: string
+): string | undefined {
+  const exactKey = `${languageCode}:${sourceFilePath}`;
+  if (missingByLocale[exactKey]) {
+    return exactKey;
+  }
+
+  return Object.keys(missingByLocale).find(key => {
+    const separatorIndex = key.indexOf(':');
+    const keyLocale = key.slice(0, separatorIndex);
+    const keySourcePath = key.slice(separatorIndex + 1);
+    return keySourcePath === sourceFilePath && localeCodesMatch(keyLocale, languageCode);
+  });
+}
+
 const WAITING_STATUSES = ['pending', 'processing', 'validating'] as const;
 
 function isWaitingStatus(status: string): boolean {
@@ -268,14 +290,15 @@ async function applyTranslations(
     return false;
   }
 
-  const localeSourceKey = `${languageCode}:${sourceInfo.sourceFilePath}`;
-  const entry = missingByLocale[localeSourceKey];
+  const localeSourceKey = findMissingEntryKey(missingByLocale, languageCode, sourceInfo.sourceFilePath);
 
-  if (!entry || processedEntries.has(localeSourceKey)) {
+  if (!localeSourceKey || processedEntries.has(localeSourceKey)) {
     return false;
   }
 
+  const entry = missingByLocale[localeSourceKey];
   const targetPath = entry.targetPath;
+  const fileLocale = localeSourceKey.slice(0, localeSourceKey.indexOf(':')) || languageCode;
   if (verbose) {
     console.log(chalk.blue(`  Updating translations for ${languageCode} in ${targetPath}`));
   }
@@ -283,7 +306,7 @@ async function applyTranslations(
   const result = await translationUtils.updateTranslationFile(
     targetPath,
     data.translations.data,
-    languageCode,
+    fileLocale,
     entry.path,
     undefined,
     config

--- a/tests/api/projects.test.js
+++ b/tests/api/projects.test.js
@@ -116,5 +116,65 @@ describe('projects API', () => {
         .rejects
         .toThrow('Project creation failed');
     });
+
+    it('sends custom_languages when customLocales are provided', async () => {
+      const projectData = {
+        name: 'x',
+        sourceLocale: 'en',
+        targetLocales: ['ja', 'ja_easy'],
+        customLocales: [{ code: 'ja_easy', name: 'Easy Japanese', baseLanguage: 'ja' }]
+      };
+      const mockResponse = {
+        project: {
+          id: 'proj_456',
+          name: 'x',
+          source_language: 'en',
+          target_languages: ['ja', 'ja_easy']
+        }
+      };
+
+      mockApiRequest.mockResolvedValueOnce(mockResponse);
+
+      await createProject(projectData);
+
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        '/api/v1/projects',
+        {
+          method: 'POST',
+          body: {
+            project: {
+              name: 'x',
+              source_language: 'en',
+              target_languages: ['ja', 'ja_easy'],
+              custom_languages: [{ code: 'ja_easy', name: 'Easy Japanese', base_language: 'ja' }]
+            }
+          },
+          apiKey: TEST_API_KEY
+        }
+      );
+    });
+
+    it('omits custom_languages key when no customLocales provided', async () => {
+      const projectData = {
+        name: 'Standard Project',
+        sourceLocale: 'en',
+        targetLocales: ['fr', 'es']
+      };
+      const mockResponse = {
+        project: {
+          id: 'proj_789',
+          name: 'Standard Project',
+          source_language: 'en',
+          target_languages: ['fr', 'es']
+        }
+      };
+
+      mockApiRequest.mockResolvedValueOnce(mockResponse);
+
+      await createProject(projectData);
+
+      const callArgs = mockApiRequest.mock.calls[0][1];
+      expect(callArgs.body.project).not.toHaveProperty('custom_languages');
+    });
   });
 });

--- a/tests/commands/init.test.js
+++ b/tests/commands/init.test.js
@@ -159,7 +159,7 @@ describe('init command', () => {
       .mockResolvedValueOnce('');
     projectApi.createProject.mockRejectedValue(new Error('API failure'));
 
-    await init(createInitDeps());
+    await expect(init(createInitDeps())).rejects.toThrow(/project creation failed/i);
 
     const allConsoleOutput = mockConsole.log.mock.calls.map(call => call[0]).join('\n');
     expect(allConsoleOutput).toContain('✗ Failed to create project: API failure');
@@ -302,6 +302,249 @@ describe('init command', () => {
     expect(allConsoleOutput).toContain('⚠️  Source language \'en\' removed from target languages');
   });
 
+  it('collects custom-locale details for non-standard target locales', async () => {
+    configUtils.getProjectConfig.mockResolvedValue(null);
+    authUtils.checkAuth.mockResolvedValue(true);
+    projectApi.listProjects.mockResolvedValue([]);
+    promptService.selectProject.mockResolvedValue({ choice: 'new' });
+    promptService.input
+      .mockResolvedValueOnce('en')
+      .mockResolvedValueOnce('ja,ja_easy')
+      .mockResolvedValueOnce('Easy Japanese')
+      .mockResolvedValueOnce('ja')
+      .mockResolvedValueOnce('test-project')
+      .mockResolvedValueOnce('locales/')
+      .mockResolvedValueOnce('');
+    projectApi.createProject.mockResolvedValue({
+      id: 'proj_123',
+      name: 'test-project'
+    });
+    promptService.confirm
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false);
+
+    await init(createInitDeps());
+
+    const inputCalls = promptService.input.mock.calls.map(call => call[0]);
+    const nameCall = inputCalls.find(opts => /Display name for 'ja_easy'/.test(opts.message));
+    expect(nameCall).toBeDefined();
+    const baseCall = inputCalls.find(opts => /Base language for 'ja_easy'/.test(opts.message));
+    expect(baseCall).toBeDefined();
+    expect(baseCall.default).toBe('ja');
+  });
+
+  it('re-asks for the base language until a 2-letter code is given', async () => {
+    configUtils.getProjectConfig.mockResolvedValue(null);
+    authUtils.checkAuth.mockResolvedValue(true);
+    projectApi.listProjects.mockResolvedValue([]);
+    promptService.selectProject.mockResolvedValue({ choice: 'new' });
+    promptService.input
+      .mockResolvedValueOnce('en')
+      .mockResolvedValueOnce('ja_easy')
+      .mockResolvedValueOnce('Easy Japanese')
+      .mockResolvedValueOnce('Japanese')
+      .mockResolvedValueOnce('JA ')
+      .mockResolvedValueOnce('test-project')
+      .mockResolvedValueOnce('locales/')
+      .mockResolvedValueOnce('');
+    projectApi.createProject.mockResolvedValue({
+      id: 'proj_123',
+      name: 'test-project'
+    });
+    promptService.confirm
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false);
+
+    await init(createInitDeps());
+
+    const baseCalls = promptService.input.mock.calls
+      .map(call => call[0])
+      .filter(opts => /Base language for 'ja_easy'/.test(opts.message));
+    expect(baseCalls.length).toBe(2);
+    expect(projectApi.createProject).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customLocales: [{ code: 'ja_easy', name: 'Easy Japanese', baseLanguage: 'ja' }]
+      })
+    );
+  });
+
+  it('does not prompt for custom-locale details when all targets are standard', async () => {
+    configUtils.getProjectConfig.mockResolvedValue(null);
+    authUtils.checkAuth.mockResolvedValue(true);
+    projectApi.listProjects.mockResolvedValue([]);
+    promptService.selectProject.mockResolvedValue({ choice: 'new' });
+    promptService.input
+      .mockResolvedValueOnce('en')
+      .mockResolvedValueOnce('fr,de')
+      .mockResolvedValueOnce('test-project')
+      .mockResolvedValueOnce('locales/')
+      .mockResolvedValueOnce('');
+    projectApi.createProject.mockResolvedValue({
+      id: 'proj_123',
+      name: 'test-project'
+    });
+    promptService.confirm
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false);
+
+    await init(createInitDeps());
+
+    const inputCalls = promptService.input.mock.calls.map(call => call[0]);
+    expect(inputCalls.some(opts => /Display name for/.test(opts.message))).toBe(false);
+    expect(configUtils.saveProjectConfig).toHaveBeenCalled();
+  });
+
+  it('passes customLocales to createProject when custom locales are declared', async () => {
+    configUtils.getProjectConfig.mockResolvedValue(null);
+    authUtils.checkAuth.mockResolvedValue(true);
+    projectApi.listProjects.mockResolvedValue([]);
+    promptService.selectProject.mockResolvedValue({ choice: 'new' });
+    promptService.input
+      .mockResolvedValueOnce('en')
+      .mockResolvedValueOnce('ja,ja_easy')
+      .mockResolvedValueOnce('Easy Japanese')
+      .mockResolvedValueOnce('ja')
+      .mockResolvedValueOnce('test-project')
+      .mockResolvedValueOnce('locales/')
+      .mockResolvedValueOnce('');
+    projectApi.createProject.mockResolvedValue({
+      id: 'proj_123',
+      name: 'test-project'
+    });
+    promptService.confirm
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false);
+
+    await init(createInitDeps());
+
+    expect(projectApi.createProject).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customLocales: [{ code: 'ja_easy', name: 'Easy Japanese', baseLanguage: 'ja' }]
+      })
+    );
+  });
+
+  it('saves customLocales in localhero.json when custom locales are declared', async () => {
+    configUtils.getProjectConfig.mockResolvedValue(null);
+    authUtils.checkAuth.mockResolvedValue(true);
+    projectApi.listProjects.mockResolvedValue([]);
+    promptService.selectProject.mockResolvedValue({ choice: 'new' });
+    promptService.input
+      .mockResolvedValueOnce('en')
+      .mockResolvedValueOnce('ja,ja_easy')
+      .mockResolvedValueOnce('Easy Japanese')
+      .mockResolvedValueOnce('ja')
+      .mockResolvedValueOnce('test-project')
+      .mockResolvedValueOnce('locales/')
+      .mockResolvedValueOnce('');
+    projectApi.createProject.mockResolvedValue({
+      id: 'proj_123',
+      name: 'test-project'
+    });
+    promptService.confirm
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false);
+
+    await init(createInitDeps());
+
+    expect(configUtils.saveProjectConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customLocales: [{ code: 'ja_easy', name: 'Easy Japanese', baseLanguage: 'ja' }]
+      }),
+      expect.any(String)
+    );
+  });
+
+  it('omits customLocales from saved config when all targets are standard', async () => {
+    configUtils.getProjectConfig.mockResolvedValue(null);
+    authUtils.checkAuth.mockResolvedValue(true);
+    projectApi.listProjects.mockResolvedValue([]);
+    promptService.selectProject.mockResolvedValue({ choice: 'new' });
+    promptService.input
+      .mockResolvedValueOnce('en')
+      .mockResolvedValueOnce('fr,de')
+      .mockResolvedValueOnce('test-project')
+      .mockResolvedValueOnce('locales/')
+      .mockResolvedValueOnce('');
+    projectApi.createProject.mockResolvedValue({
+      id: 'proj_123',
+      name: 'test-project'
+    });
+    promptService.confirm
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false);
+
+    await init(createInitDeps());
+
+    const savedConfig = configUtils.saveProjectConfig.mock.calls[0][0];
+    expect(savedConfig).not.toHaveProperty('customLocales');
+  });
+
+  it('does not prompt for region-shaped locale codes and passes them through raw', async () => {
+    configUtils.getProjectConfig.mockResolvedValue(null);
+    authUtils.checkAuth.mockResolvedValue(true);
+    projectApi.listProjects.mockResolvedValue([]);
+    promptService.selectProject.mockResolvedValue({ choice: 'new' });
+    promptService.input
+      .mockResolvedValueOnce('en')
+      .mockResolvedValueOnce('ja,zh_cn')
+      .mockResolvedValueOnce('test-project')
+      .mockResolvedValueOnce('locales/')
+      .mockResolvedValueOnce('');
+    projectApi.createProject.mockResolvedValue({
+      id: 'proj_123',
+      name: 'test-project'
+    });
+    promptService.confirm
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false);
+
+    await init(createInitDeps());
+
+    const inputCalls = promptService.input.mock.calls.map(call => call[0]);
+    expect(inputCalls.some(opts => /Display name for/.test(opts.message))).toBe(false);
+    expect(projectApi.createProject).toHaveBeenCalledWith(
+      expect.objectContaining({ targetLocales: ['ja', 'zh_cn'] })
+    );
+    expect(projectApi.createProject.mock.calls[0][0]).not.toHaveProperty('customLocales');
+  });
+
+  it('prompts only for truly custom codes when mixed with region-shaped codes', async () => {
+    configUtils.getProjectConfig.mockResolvedValue(null);
+    authUtils.checkAuth.mockResolvedValue(true);
+    projectApi.listProjects.mockResolvedValue([]);
+    promptService.selectProject.mockResolvedValue({ choice: 'new' });
+    promptService.input
+      .mockResolvedValueOnce('en')
+      .mockResolvedValueOnce('ja_easy,zh_cn')
+      .mockResolvedValueOnce('Easy Japanese')
+      .mockResolvedValueOnce('ja')
+      .mockResolvedValueOnce('test-project')
+      .mockResolvedValueOnce('locales/')
+      .mockResolvedValueOnce('');
+    projectApi.createProject.mockResolvedValue({
+      id: 'proj_123',
+      name: 'test-project'
+    });
+    promptService.confirm
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false);
+
+    await init(createInitDeps());
+
+    const displayNameCalls = promptService.input.mock.calls
+      .map(call => call[0])
+      .filter(opts => /Display name for/.test(opts.message));
+    expect(displayNameCalls.length).toBe(1);
+    expect(displayNameCalls[0].message).toMatch(/'ja_easy'/);
+    expect(projectApi.createProject).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targetLocales: ['ja_easy', 'zh_cn'],
+        customLocales: [{ code: 'ja_easy', name: 'Easy Japanese', baseLanguage: 'ja' }]
+      })
+    );
+  });
+
   describe('non-interactive mode', () => {
     const baseFlags = {
       yes: true,
@@ -369,6 +612,40 @@ describe('init command', () => {
         }),
         expect.any(String)
       );
+    });
+
+    it('accepts region-shaped locale codes without rejection', async () => {
+      configUtils.getProjectConfig.mockResolvedValue(null);
+      authUtils.checkAuth.mockResolvedValue(true);
+      projectApi.listProjects.mockResolvedValue([]);
+      projectApi.createProject.mockResolvedValue({
+        id: 'proj_new',
+        name: 'noodling',
+        url: 'https://localhero.ai/projects/proj_new'
+      });
+
+      await init(createInitDeps({
+        options: { ...baseFlags, projectName: 'noodling', targetLocales: 'sv,zh_cn' }
+      }));
+
+      expect(projectApi.createProject).toHaveBeenCalledWith({
+        name: 'noodling',
+        sourceLocale: 'en',
+        targetLocales: ['sv', 'zh_cn']
+      });
+      expect(configUtils.saveProjectConfig).toHaveBeenCalled();
+    });
+
+    it('throws when target locales include a non-standard code', async () => {
+      configUtils.getProjectConfig.mockResolvedValue(null);
+      authUtils.checkAuth.mockResolvedValue(true);
+
+      await expect(init(createInitDeps({
+        options: { ...baseFlags, targetLocales: 'fr,ja_easy' }
+      }))).rejects.toThrow(/ja_easy.*interactively/s);
+
+      expect(configUtils.saveProjectConfig).not.toHaveBeenCalled();
+      expect(projectApi.createProject).not.toHaveBeenCalled();
     });
 
     it('throws a clear error when required flags are missing', async () => {

--- a/tests/utils/config.test.js
+++ b/tests/utils/config.test.js
@@ -307,6 +307,31 @@ describe('config module', () => {
 
             await expect(configService.validateProjectConfig(validConfig)).resolves.toBe(true);
         });
+
+        it('throws when a customLocales code is not listed in outputLocales', async () => {
+            const invalidConfig = {
+                projectId: 'test-project',
+                sourceLocale: 'en',
+                outputLocales: ['fr'],
+                translationFiles: { paths: ['locales/'] },
+                customLocales: [{ code: 'ja_easy', name: 'x', baseLanguage: 'ja' }]
+            };
+
+            await expect(configService.validateProjectConfig(invalidConfig))
+                .rejects.toThrow(/customLocales codes must also be listed in outputLocales: ja_easy/);
+        });
+
+        it('passes when all customLocales codes are present in outputLocales', async () => {
+            const validConfig = {
+                projectId: 'test-project',
+                sourceLocale: 'en',
+                outputLocales: ['fr', 'ja_easy'],
+                translationFiles: { paths: ['locales/'] },
+                customLocales: [{ code: 'ja_easy', name: 'Easy Japanese', baseLanguage: 'ja' }]
+            };
+
+            await expect(configService.validateProjectConfig(validConfig)).resolves.toBe(true);
+        });
     });
 
     describe('getValidProjectConfig', () => {

--- a/tests/utils/extract-locale-from-path.test.ts
+++ b/tests/utils/extract-locale-from-path.test.ts
@@ -80,6 +80,98 @@ describe('extractLocaleFromPath — knownLocales empty', () => {
   });
 });
 
+describe('custom and underscore locales via knownLocales', () => {
+  const knownLocales = ['en', 'ja', 'ja_easy', 'zh_cn'];
+
+  it('extracts a custom locale from the basename when declared in knownLocales', () => {
+    expect(extractLocaleFromPath('config/locales/ja_easy.yml', undefined, knownLocales)).toBe('ja_easy');
+  });
+
+  it('extracts an underscore locale from the basename when in knownLocales', () => {
+    expect(extractLocaleFromPath('config/locales/zh_cn.yml', undefined, knownLocales)).toBe('zh_cn');
+  });
+
+  it('returns the knownLocales spelling when the filename casing differs', () => {
+    expect(extractLocaleFromPath('config/locales/JA_EASY.yml', undefined, knownLocales)).toBe('ja_easy');
+  });
+
+  it('extracts a custom locale from a path segment', () => {
+    expect(extractLocaleFromPath('locales/ja_easy/messages.yml', undefined, knownLocales)).toBe('ja_easy');
+  });
+
+  it('still throws for non-standard codes NOT in knownLocales', () => {
+    expect(() => extractLocaleFromPath('config/locales/xx_unknown.yml', undefined, knownLocales))
+      .toThrow(/Could not extract locale from path/);
+  });
+
+  it('extracts a standard locale from the basename when in knownLocales', () => {
+    expect(extractLocaleFromPath('config/locales/en.yml', undefined, knownLocales)).toBe('en');
+  });
+
+  it('extracts a standard regional locale when knownLocales is empty', () => {
+    expect(extractLocaleFromPath('config/locales/fr-CA.yml', undefined, [])).toBe('fr-CA');
+  });
+});
+
+describe('dotted basename last-segment matching via knownLocales', () => {
+  const knownLocales = ['en', 'ja', 'ja_easy', 'zh_cn'];
+
+  it('extracts ja_easy from devise.ja_easy.yml', () => {
+    expect(extractLocaleFromPath('config/locales/devise.ja_easy.yml', undefined, knownLocales)).toBe('ja_easy');
+  });
+
+  it('extracts zh_cn from messages.zh_cn.yaml', () => {
+    expect(extractLocaleFromPath('config/locales/messages.zh_cn.yaml', undefined, knownLocales)).toBe('zh_cn');
+  });
+
+  it('extracts ja_easy from devise.JA_EASY.yml (case-insensitive)', () => {
+    expect(extractLocaleFromPath('config/locales/devise.JA_EASY.yml', undefined, knownLocales)).toBe('ja_easy');
+  });
+
+  it('throws when last segment is not a known locale', () => {
+    expect(() => extractLocaleFromPath('config/locales/devise.xx_nope.yml', undefined, knownLocales))
+      .toThrow(/Could not extract locale from path/);
+  });
+
+  it('extracts en from devise.en.yml (standard code via regex, unaffected by change)', () => {
+    expect(extractLocaleFromPath('config/locales/devise.en.yml', undefined, knownLocales)).toBe('en');
+  });
+});
+
+describe('separator-suffix matching via knownLocales', () => {
+  const knownLocales = ['en', 'fr', 'ja', 'ja_easy', 'zh_cn'];
+
+  it('extracts zh_cn from messages_zh_cn.yml', () => {
+    expect(extractLocaleFromPath('config/locales/messages_zh_cn.yml', undefined, knownLocales)).toBe('zh_cn');
+  });
+
+  it('extracts ja_easy from messages-ja_easy.yml', () => {
+    expect(extractLocaleFromPath('config/locales/messages-ja_easy.yml', undefined, knownLocales)).toBe('ja_easy');
+  });
+
+  it('extracts ja_easy from django_ja_easy.po', () => {
+    expect(extractLocaleFromPath('locale/django_ja_easy.po', undefined, knownLocales)).toBe('ja_easy');
+  });
+
+  it('returns the knownLocales spelling when the suffix casing differs', () => {
+    expect(extractLocaleFromPath('config/locales/messages_ZH_CN.yml', undefined, knownLocales)).toBe('zh_cn');
+  });
+
+  it('prefers a locale path segment over a basename suffix', () => {
+    expect(extractLocaleFromPath('locales/fr/messages_zh_cn.yml', undefined, knownLocales)).toBe('fr');
+  });
+
+  it('throws when the suffix is not a known locale', () => {
+    expect(() => extractLocaleFromPath('config/locales/messages_xx_nope.yml', undefined, knownLocales))
+      .toThrow(/Could not extract locale from path/);
+  });
+
+  it('does not treat a word ending in a locale as a suffix without a separator', () => {
+    expect(() => extractLocaleFromPath('config/locales/kitchen.yml', undefined, knownLocales))
+      .toThrow(/Could not extract locale from path/);
+  });
+});
+
 describe('extractLocaleFromPath — custom regex', () => {
   it('returns captured locale when user-supplied custom regex matches, even if not in knownLocales', () => {
     // When the caller provides their own regex, we trust it — useful for

--- a/tests/utils/sync-service.test.js
+++ b/tests/utils/sync-service.test.js
@@ -212,6 +212,14 @@ describe('syncService', () => {
   });
 
   describe('applyUpdates', () => {
+    beforeEach(() => {
+      mockConfigService.getValidProjectConfig.mockResolvedValue({
+        projectId: 'test-project',
+        sourceLocale: 'en',
+        outputLocales: ['fr']
+      });
+    });
+
     const testUpdates = {
       updates: {
         files: [
@@ -277,6 +285,87 @@ describe('syncService', () => {
         }
       );
       expect(mockConfigService.updateLastSyncedAt).toHaveBeenCalled();
+    });
+
+    it('writes updates under the config locale spelling when the backend reports canonical codes', async () => {
+      mockConfigService.getValidProjectConfig.mockResolvedValue({
+        projectId: 'test-project',
+        sourceLocale: 'en',
+        outputLocales: ['zh_cn', 'ja_easy']
+      });
+
+      mockFilesUtils.findTranslationFiles.mockResolvedValueOnce({
+        sourceFiles: [{ path: 'config/locales/en.yml', locale: 'en' }],
+        allFiles: [],
+        targetFilesByLocale: {}
+      });
+
+      mockTranslationUpdater.updateTranslationFile.mockResolvedValue({
+        updatedKeys: ['greeting'],
+        created: false
+      });
+      mockConfigService.updateLastSyncedAt.mockResolvedValue();
+
+      const canonicalUpdates = {
+        updates: {
+          files: [
+            {
+              path: 'config/locales/zh_cn.yml',
+              languages: [
+                { code: 'zh-CN', translations: [{ key: 'greeting', value: '你好' }] }
+              ]
+            },
+            {
+              path: 'config/locales/ja_easy.yml',
+              languages: [
+                { code: 'ja_easy', translations: [{ key: 'greeting', value: 'こんにちは' }] }
+              ]
+            }
+          ]
+        }
+      };
+
+      await syncService.applyUpdates(canonicalUpdates);
+
+      const languageCodes = mockTranslationUpdater.updateTranslationFile.mock.calls.map(call => call[2]);
+      expect(languageCodes).toEqual(['zh_cn', 'ja_easy']);
+    });
+
+    it('passes the backend code through when it matches no config locale', async () => {
+      mockConfigService.getValidProjectConfig.mockResolvedValue({
+        projectId: 'test-project',
+        sourceLocale: 'en',
+        outputLocales: ['fr']
+      });
+
+      mockFilesUtils.findTranslationFiles.mockResolvedValueOnce({
+        sourceFiles: [],
+        allFiles: [],
+        targetFilesByLocale: {}
+      });
+
+      mockTranslationUpdater.updateTranslationFile.mockResolvedValue({
+        updatedKeys: ['greeting'],
+        created: false
+      });
+      mockConfigService.updateLastSyncedAt.mockResolvedValue();
+
+      const unconfiguredUpdates = {
+        updates: {
+          files: [
+            {
+              path: 'locales/de.json',
+              languages: [
+                { code: 'de', translations: [{ key: 'greeting', value: 'Hallo' }] }
+              ]
+            }
+          ]
+        }
+      };
+
+      await syncService.applyUpdates(unconfiguredUpdates);
+
+      expect(mockTranslationUpdater.updateTranslationFile.mock.calls[0][2]).toBe('de');
     });
 
     it('handles file update errors', async () => {

--- a/tests/utils/translation-processor.test.js
+++ b/tests/utils/translation-processor.test.js
@@ -496,6 +496,173 @@ describe('translation-processor', () => {
       expect(result.uniqueKeysTranslated.size).toBe(2); // welcome and title
     });
 
+    it('applies translations when backend reports canonical locale code for underscore config locale', async () => {
+      const batches = [
+        {
+          sourceFilePath: 'config/locales/en.yml',
+          sourceFile: {
+            path: 'config/locales/en.yml',
+            format: 'yaml',
+            content: Buffer.from('en:\n  welcome: Welcome\n').toString('base64')
+          },
+          localeEntries: ['zh_cn:config/locales/en.yml'],
+          locales: ['zh_cn']
+        }
+      ];
+
+      const missingByLocale = {
+        'zh_cn:config/locales/en.yml': {
+          locale: 'zh_cn',
+          path: 'config/locales/en.yml',
+          targetPath: 'config/locales/zh_cn.yml',
+          keys: { welcome: { value: 'Welcome', sourceKey: 'welcome' } },
+          keyCount: 1
+        }
+      };
+
+      const config = { projectId: 'test-project' };
+
+      mockTranslationUtils.createTranslationJob.mockResolvedValue({
+        jobs: [{ id: 'job-zh', language: { code: 'zh-CN' } }]
+      });
+
+      mockTranslationUtils.checkJobStatus.mockResolvedValue({
+        status: 'completed',
+        translations: {
+          data: { welcome: '欢迎' }
+        },
+        language: { code: 'zh-CN' }
+      });
+
+      const result = await processTranslationBatches(
+        batches,
+        missingByLocale,
+        config,
+        true,
+        { console: mockConsole, translationUtils: mockTranslationUtils }
+      );
+
+      expect(mockTranslationUtils.updateTranslationFile).toHaveBeenCalledWith(
+        'config/locales/zh_cn.yml',
+        { welcome: '欢迎' },
+        'zh_cn',
+        'config/locales/en.yml',
+        undefined,
+        { projectId: 'test-project' }
+      );
+      expect(result.totalLanguages).toBe(1);
+      expect(result.languages).toEqual(['zh-CN']);
+      expect(result.uniqueKeysTranslated.has('welcome')).toBe(true);
+    });
+
+    it('applies translations for custom locale codes returned literally', async () => {
+      const batches = [
+        {
+          sourceFilePath: 'config/locales/en.yml',
+          sourceFile: {
+            path: 'config/locales/en.yml',
+            format: 'yaml',
+            content: Buffer.from('en:\n  welcome: Welcome\n').toString('base64')
+          },
+          localeEntries: ['ja_easy:config/locales/en.yml'],
+          locales: ['ja_easy']
+        }
+      ];
+
+      const missingByLocale = {
+        'ja_easy:config/locales/en.yml': {
+          locale: 'ja_easy',
+          path: 'config/locales/en.yml',
+          targetPath: 'config/locales/ja_easy.yml',
+          keys: { welcome: { value: 'Welcome', sourceKey: 'welcome' } },
+          keyCount: 1
+        }
+      };
+
+      const config = { projectId: 'test-project' };
+
+      mockTranslationUtils.createTranslationJob.mockResolvedValue({
+        jobs: [{ id: 'job-ja-easy', language: { code: 'ja_easy' } }]
+      });
+
+      mockTranslationUtils.checkJobStatus.mockResolvedValue({
+        status: 'completed',
+        translations: {
+          data: { welcome: 'ようこそ' }
+        },
+        language: { code: 'ja_easy' }
+      });
+
+      const result = await processTranslationBatches(
+        batches,
+        missingByLocale,
+        config,
+        true,
+        { console: mockConsole, translationUtils: mockTranslationUtils }
+      );
+
+      expect(mockTranslationUtils.updateTranslationFile).toHaveBeenCalledWith(
+        'config/locales/ja_easy.yml',
+        { welcome: 'ようこそ' },
+        'ja_easy',
+        'config/locales/en.yml',
+        undefined,
+        { projectId: 'test-project' }
+      );
+      expect(result.totalLanguages).toBe(1);
+      expect(result.languages).toEqual(['ja_easy']);
+    });
+
+    it('does not apply translations when locale codes differ beyond casing and separators', async () => {
+      const batches = [
+        {
+          sourceFilePath: 'config/locales/en.yml',
+          sourceFile: {
+            path: 'config/locales/en.yml',
+            format: 'yaml',
+            content: Buffer.from('en:\n  welcome: Welcome\n').toString('base64')
+          },
+          localeEntries: ['zh_cn:config/locales/en.yml'],
+          locales: ['zh_cn']
+        }
+      ];
+
+      const missingByLocale = {
+        'zh_cn:config/locales/en.yml': {
+          locale: 'zh_cn',
+          path: 'config/locales/en.yml',
+          targetPath: 'config/locales/zh_cn.yml',
+          keys: { welcome: { value: 'Welcome', sourceKey: 'welcome' } },
+          keyCount: 1
+        }
+      };
+
+      const config = { projectId: 'test-project' };
+
+      mockTranslationUtils.createTranslationJob.mockResolvedValue({
+        jobs: [{ id: 'job-zh-tw', language: { code: 'zh-TW' } }]
+      });
+
+      mockTranslationUtils.checkJobStatus.mockResolvedValue({
+        status: 'completed',
+        translations: {
+          data: { welcome: '歡迎' }
+        },
+        language: { code: 'zh-TW' }
+      });
+
+      const result = await processTranslationBatches(
+        batches,
+        missingByLocale,
+        config,
+        true,
+        { console: mockConsole, translationUtils: mockTranslationUtils }
+      );
+
+      expect(mockTranslationUtils.updateTranslationFile).not.toHaveBeenCalled();
+      expect(result.totalLanguages).toBe(0);
+    });
+
     it('handles a job that repeatedly stays pending and hits max tries', async () => {
       const testJobId = 'job-always-pending';
 


### PR DESCRIPTION

### What

- **`extractLocaleFromPath` trusts explicit `knownLocales` matches** (exact-first, case-insensitive fallback, last-dot-segment for namespaced files, separator-suffix for names like `messages_zh_cn.yml`) — `ja_easy.yml`, `zh_cn.yml`, `devise.ja_easy.yml` are scanned instead of silently skipped.
- **Interactive `init` declares non-standard targets**: prompts for a display name and base language (`Base language for 'ja_easy' (a 2-letter code, like "ja" for Japanese):` with a re-ask loop on invalid input) for codes outside the standard shapes. Region-shaped codes like `zh_cn` skip the prompts entirely — the backend normalizes them to `zh-CN`. `--yes` mode rejects truly unknown codes with an actionable error (interactive-only for v1). `--project-id` mode unaffected (locales come from the project).
- **`createProject` sends `custom_languages`** (snake_case; key absent when none) and `customLocales` persists in `localhero.json`, validated ⊆ `outputLocales`.
- **`init` exits non-zero when project creation fails** (previously exited 0 with the error only printed).
- **Translate and pull write under the raw config locale** (each fix TDD'd with a repro): job results and sync updates reported with canonical codes (`zh-CN`) fold back to the config spelling (`zh_cn`) before writing, preventing double `zh_cn:`/`zh-CN:` YAML wrappers and infinite re-translate loops.
- CLI never canonicalizes: raw codes everywhere (`target_languages`, `target_paths` keys, wrappers, filenames); the backend is the sole authority.

### Testing

- 789 tests green; lint + build clean.
- Live e2e in the testbed repo: `push` (168 translations, zero skips), `translate` filling all 9 customer locales to 21/21 keys with in-place updates to the customer's filenames, rerun → "All translations are up to date" (idempotent).
- Full `ci` PR flow against the dev backend: 9/9 locales translated, commit-back under the customer's filenames, pending-key lifecycle verified.
- Regression runs on the Django demo, the Lingui test project, and the published CLI flow.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
