### PR TITLE
Resolve gettext locales from LC_MESSAGES path + scope import to configured locales

### DIFF
--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -93,6 +93,13 @@ export function extractLocaleFromPath(filePath: string, localeRegex?: string, kn
     return dirNameOriginal;
   }
 
+  if (dirNameOriginal === 'LC_MESSAGES') {
+    const gettextLocale = path.basename(path.dirname(path.dirname(filePath)));
+    if (gettextLocale && isGettextLocale(gettextLocale)) {
+      return gettextLocale;
+    }
+  }
+
   const filenameOriginal = path.basename(filePath);
   const regexPattern = new RegExp(effectiveLocaleRegex);
   const regexMatch = filenameOriginal.match(regexPattern);
@@ -119,6 +126,12 @@ export function isValidLocale(locale: string): boolean {
   // Basic validation for language code (2 letters) or language-region code (e.g., en-US or en-us)
   // Case insensitive for better compatibility with existing code
   return /^[a-zA-Z]{2}(?:-[a-zA-Z]{2})?$/.test(locale);
+}
+
+function isGettextLocale(dirName: string): boolean {
+  // gettext locale directories allow an underscore-separated region (pt_BR) in
+  // addition to the dash form, e.g. priv/gettext/<locale>/LC_MESSAGES/<domain>.po
+  return /^[a-zA-Z]{2,3}(?:[_-][a-zA-Z]{2,4})?$/.test(dirName);
 }
 
 const PO_LEAF_KEYS = new Set(['value', 'context', 'metadata']);

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -94,8 +94,12 @@ export function extractLocaleFromPath(filePath: string, localeRegex?: string, kn
   }
 
   if (dirNameOriginal === 'LC_MESSAGES') {
-    const gettextLocale = path.basename(path.dirname(path.dirname(filePath)));
-    if (gettextLocale && isGettextLocale(gettextLocale)) {
+    const localeDir = path.dirname(path.dirname(filePath));
+    const gettextLocale = path.basename(localeDir);
+    // In a gettext layout the directory directly above LC_MESSAGES is always the
+    // locale (priv/gettext/<locale>/LC_MESSAGES/<domain>.po), so trust it even for
+    // custom or non-standard codes. Guard against LC_MESSAGES sitting at the root.
+    if (gettextLocale && gettextLocale !== localeDir && gettextLocale !== '.') {
       return gettextLocale;
     }
   }
@@ -126,12 +130,6 @@ export function isValidLocale(locale: string): boolean {
   // Basic validation for language code (2 letters) or language-region code (e.g., en-US or en-us)
   // Case insensitive for better compatibility with existing code
   return /^[a-zA-Z]{2}(?:-[a-zA-Z]{2})?$/.test(locale);
-}
-
-function isGettextLocale(dirName: string): boolean {
-  // gettext locale directories allow an underscore-separated region (pt_BR) in
-  // addition to the dash form, e.g. priv/gettext/<locale>/LC_MESSAGES/<domain>.po
-  return /^[a-zA-Z]{2,3}(?:[_-][a-zA-Z]{2,4})?$/.test(dirName);
 }
 
 const PO_LEAF_KEYS = new Set(['value', 'context', 'metadata']);

--- a/src/utils/import-service.ts
+++ b/src/utils/import-service.ts
@@ -6,6 +6,7 @@ import { createImport, checkImportStatus, ImportResponse, bulkUpdateTranslations
 import { findTranslationFiles as findFiles, flattenTranslations } from './files.js';
 import { parsePoFile, poEntriesToApiFormat } from './po-utils.js';
 import { filterFilesByGitChanges } from './git-changes.js';
+import { localeCodesMatch } from './translation-processor.js';
 import { detectMultiLanguage } from './multi-language-detection.js';
 import type { IgnoreSummary, RemovedKey } from './ignore-keys.js';
 import { summarizeRemoved } from './ignore-keys.js';
@@ -80,6 +81,14 @@ function normalizeFormat(format: string): string {
   if (format === 'yml') return 'yaml';
   if (format === 'pot') return 'po';
   return format;
+}
+
+export function isConfiguredTargetLocale(outputLocales: string[], language: string): boolean {
+  // An empty outputLocales means "no restriction" (validated configs always have
+  // at least one). Match tolerantly so a config locale (pt-BR) still matches a
+  // gettext directory name (pt_BR).
+  return outputLocales.length === 0 ||
+    outputLocales.some(locale => localeCodesMatch(locale, language));
 }
 
 let poWarningEmitted = false;
@@ -334,12 +343,9 @@ export const importService = {
     }
 
     const outputLocales = config.outputLocales ?? [];
-    const isConfiguredTarget = (language: string): boolean =>
-      outputLocales.length === 0 || outputLocales.includes(language);
-
     const sourceFiles = files.filter(file => file.language === config.sourceLocale);
     const targetFiles = files.filter(
-      file => file.language !== config.sourceLocale && isConfiguredTarget(file.language)
+      file => file.language !== config.sourceLocale && isConfiguredTargetLocale(outputLocales, file.language)
     );
     const importedFiles = {
       source: sourceFiles,

--- a/src/utils/import-service.ts
+++ b/src/utils/import-service.ts
@@ -333,8 +333,14 @@ export const importService = {
       return { status: 'no_files' };
     }
 
+    const outputLocales = config.outputLocales ?? [];
+    const isConfiguredTarget = (language: string): boolean =>
+      outputLocales.length === 0 || outputLocales.includes(language);
+
     const sourceFiles = files.filter(file => file.language === config.sourceLocale);
-    const targetFiles = files.filter(file => file.language !== config.sourceLocale);
+    const targetFiles = files.filter(
+      file => file.language !== config.sourceLocale && isConfiguredTarget(file.language)
+    );
     const importedFiles = {
       source: sourceFiles,
       target: targetFiles

--- a/tests/utils/extract-locale-from-path.test.ts
+++ b/tests/utils/extract-locale-from-path.test.ts
@@ -172,6 +172,31 @@ describe('separator-suffix matching via knownLocales', () => {
   });
 });
 
+describe('gettext LC_MESSAGES layout', () => {
+  const knownLocales = ['en', 'sv', 'da', 'de'];
+
+  it('extracts the locale from the directory above LC_MESSAGES when known', () => {
+    expect(extractLocaleFromPath('priv/gettext/sv/LC_MESSAGES/errors.po', undefined, knownLocales)).toBe('sv');
+  });
+
+  it('extracts the locale from an umbrella gettext path when known', () => {
+    expect(extractLocaleFromPath('apps/myapp_web/priv/gettext/da/LC_MESSAGES/default.po', undefined, knownLocales)).toBe('da');
+  });
+
+  it('extracts a gettext locale from the directory structure even when not in knownLocales', () => {
+    expect(extractLocaleFromPath('apps/myapp_web/priv/gettext/fr/LC_MESSAGES/errors.po', undefined, knownLocales)).toBe('fr');
+  });
+
+  it('extracts a regional gettext locale from the directory structure', () => {
+    expect(extractLocaleFromPath('priv/gettext/pt_BR/LC_MESSAGES/default.po', undefined, knownLocales)).toBe('pt_BR');
+  });
+
+  it('throws when the gettext locale directory is not a valid locale', () => {
+    expect(() => extractLocaleFromPath('priv/gettext/sources/LC_MESSAGES/errors.po', undefined, knownLocales))
+      .toThrow(/Could not extract locale from path/);
+  });
+});
+
 describe('extractLocaleFromPath — custom regex', () => {
   it('returns captured locale when user-supplied custom regex matches, even if not in knownLocales', () => {
     // When the caller provides their own regex, we trust it — useful for

--- a/tests/utils/extract-locale-from-path.test.ts
+++ b/tests/utils/extract-locale-from-path.test.ts
@@ -191,8 +191,16 @@ describe('gettext LC_MESSAGES layout', () => {
     expect(extractLocaleFromPath('priv/gettext/pt_BR/LC_MESSAGES/default.po', undefined, knownLocales)).toBe('pt_BR');
   });
 
-  it('throws when the gettext locale directory is not a valid locale', () => {
-    expect(() => extractLocaleFromPath('priv/gettext/sources/LC_MESSAGES/errors.po', undefined, knownLocales))
+  it('extracts a custom locale directory from the gettext layout', () => {
+    expect(extractLocaleFromPath('priv/gettext/ja_easy/LC_MESSAGES/default.po', undefined, knownLocales)).toBe('ja_easy');
+  });
+
+  it('trusts any directory above LC_MESSAGES as the locale, including non-standard codes', () => {
+    expect(extractLocaleFromPath('priv/gettext/valencia/LC_MESSAGES/errors.po', undefined, knownLocales)).toBe('valencia');
+  });
+
+  it('throws when there is no directory above LC_MESSAGES', () => {
+    expect(() => extractLocaleFromPath('LC_MESSAGES/errors.po', undefined, knownLocales))
       .toThrow(/Could not extract locale from path/);
   });
 });

--- a/tests/utils/import-service.test.js
+++ b/tests/utils/import-service.test.js
@@ -346,6 +346,40 @@ describe('importService', () => {
       ]);
       expect(result.statistics).toBeDefined();
     });
+
+    it('excludes locales that are not in outputLocales from the import payload', async () => {
+      const scopedConfig = {
+        projectId: 'test-project',
+        sourceLocale: 'en',
+        outputLocales: ['sv'],
+        translationFiles: { paths: ['locales'], ignore: [] }
+      };
+
+      const files = [
+        path.join(TEST_BASE_PATH, 'locales/en.json'),
+        path.join(TEST_BASE_PATH, 'locales/sv.json'),
+        path.join(TEST_BASE_PATH, 'locales/fr.json')
+      ];
+
+      mockGlob.mockResolvedValue(files);
+      mockFs.promises.readFile.mockImplementation((filePath) => {
+        if (filePath.endsWith('en.json')) return Promise.resolve('{"hello":"Hello"}');
+        if (filePath.endsWith('sv.json')) return Promise.resolve('{"hello":"Hej"}');
+        if (filePath.endsWith('fr.json')) return Promise.resolve('{"hello":"Bonjour"}');
+        return Promise.reject(new Error(`Unexpected file: ${filePath}`));
+      });
+
+      mockImportsApi.createImport.mockResolvedValue({
+        import: { status: 'completed', id: 'import-123', statistics: { total_keys: 1, languages: [] }, warnings: [], translations_url: 'http://example.com' }
+      });
+
+      const result = await importService.importTranslations(scopedConfig, TEST_BASE_PATH);
+
+      expect(result.status).toBe('completed');
+      const languages = mockImportsApi.createImport.mock.calls[0][0].translations.map(t => t.language);
+      expect(languages).toEqual(['en', 'sv']);
+      expect(languages).not.toContain('fr');
+    });
   });
 
   describe('pushTranslations', () => {

--- a/tests/utils/import-service.test.js
+++ b/tests/utils/import-service.test.js
@@ -9,6 +9,7 @@ describe('importService', () => {
   let mockFs;
   let mockImportsApi;
   let importService;
+  let isConfiguredTargetLocale;
   let originalConsole;
 
   beforeEach(async () => {
@@ -118,6 +119,7 @@ describe('importService', () => {
 
     const importServiceModule = await import('../../src/utils/import-service.js');
     importService = importServiceModule.importService;
+    isConfiguredTargetLocale = importServiceModule.isConfiguredTargetLocale;
   });
 
   afterEach(() => {
@@ -379,6 +381,29 @@ describe('importService', () => {
       const languages = mockImportsApi.createImport.mock.calls[0][0].translations.map(t => t.language);
       expect(languages).toEqual(['en', 'sv']);
       expect(languages).not.toContain('fr');
+    });
+
+  });
+
+  describe('isConfiguredTargetLocale', () => {
+    it('includes an exact configured locale', () => {
+      expect(isConfiguredTargetLocale(['sv', 'da'], 'sv')).toBe(true);
+    });
+
+    it('excludes a locale that is not configured', () => {
+      expect(isConfiguredTargetLocale(['sv', 'da'], 'fr')).toBe(false);
+    });
+
+    it('matches across separator differences (config pt-BR vs gettext dir pt_BR)', () => {
+      expect(isConfiguredTargetLocale(['pt-BR'], 'pt_BR')).toBe(true);
+    });
+
+    it('matches case-insensitively', () => {
+      expect(isConfiguredTargetLocale(['pt-BR'], 'PT_br')).toBe(true);
+    });
+
+    it('treats an empty outputLocales as no restriction', () => {
+      expect(isConfiguredTargetLocale([], 'anything')).toBe(true);
     });
   });
 


### PR DESCRIPTION
## What

Two related fixes for Phoenix/gettext (`.po`) projects:

1. **Resolve the locale from the gettext directory structure.** gettext files live at `<locale>/LC_MESSAGES/<domain>.po`, so the locale is the *grandparent* directory. `extractLocaleFromPath` only checked the immediate parent (`LC_MESSAGES`), so any locale **not already listed in config** fell through to `Could not extract locale from path` and was silently skipped. It also rejected underscore-region codes like `pt_BR`. Added a gettext-aware fallback that reads the grandparent dir and accepts `xx`, `xx_XX`, and `xx-XX` forms.

2. **Scope the import payload to configured locales.** Resolving more locales exposed that `importTranslations` uploaded *every* discovered target file with no check against `outputLocales`. Without (1) those files threw and were skipped; with (1) they'd be uploaded and bloat the payload. Now target files are filtered to `sourceLocale + outputLocales`. No-op when `outputLocales` is unset, so existing configs are unaffected.

## Why

A real customer (Phoenix umbrella app, `apps/<app>/priv/gettext/<locale>/LC_MESSAGES/{errors,default}.po`) saw confusing `Could not extract locale from path` warnings for locales they hadn't configured (lv/lt/fr/et). The message read like a parse failure when it actually meant "not in your config" + the parser didn't understand the gettext layout.

## Behavior after this change

For that customer's tree (`outputLocales: [da,de,fi,nb,nl,pl,sv]`):
- `lv/lt/fr/et` → now recognized **and** correctly excluded (not in `outputLocales`) — no more scary warning, and they don't enter the import payload.
- configured locales → imported as before, with a smaller payload.
