### PR TITLE
Fix YAML formatting bugs

### DIFF
--- a/src/utils/translation-updater/common.ts
+++ b/src/utils/translation-updater/common.ts
@@ -4,6 +4,7 @@ import path from 'path';
 export const SPECIAL_CHARS_REGEX = /[:@#,[\]{}?|>&*!\n]/;
 export const INTERPOLATION = '%{';
 export const MAX_ARRAY_LENGTH = 1000;
+export const CLDR_PLURAL_CATEGORIES = ['zero', 'one', 'two', 'few', 'many', 'other'];
 
 /**
  * Checks if a file exists at the specified path

--- a/src/utils/translation-updater/yaml-handler.ts
+++ b/src/utils/translation-updater/yaml-handler.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from 'fs';
 import yaml from 'yaml';
-import { SPECIAL_CHARS_REGEX, INTERPOLATION, fileExists, tryParseJsonArray } from './common.js';
+import { SPECIAL_CHARS_REGEX, INTERPOLATION, CLDR_PLURAL_CATEGORIES, fileExists, tryParseJsonArray } from './common.js';
 import {
   spliceYamlUpdate,
   spliceYamlDelete,
@@ -84,6 +84,20 @@ function shouldForceQuotes(str: unknown): boolean {
   return needsQuotes(str);
 }
 
+// A node worth preserving as `.other` when a flat value is migrated into a
+// plural map: a scalar with a real value, or a non-empty sequence. Blank
+// scalars and empty sequences carry nothing to keep.
+function hasPreservableNode(node: unknown): boolean {
+  if (yaml.isScalar(node)) {
+    const value = node.value;
+    return value !== undefined && value !== null && value !== '';
+  }
+  if (yaml.isSeq(node)) {
+    return node.items.length > 0;
+  }
+  return false;
+}
+
 function processArrayItems(array: unknown[], yamlDoc: yaml.Document): YamlNode[] {
   return array.map(item => {
     const itemNode = yamlDoc.createNode(item) as YamlNode;
@@ -154,9 +168,14 @@ async function updateYamlTranslations(
       if (!current.has(key)) {
         current.set(key, yamlDoc.createNode({}));
       }
-      const nextNode = current.get(key);
+      const nextNode = current.get(key, true);
       if (!yaml.isMap(nextNode)) {
         const newNode = yamlDoc.createNode({}) as YamlMap;
+        const nestingTerminalPluralCategory = i + 1 === keys.length - 1 &&
+          CLDR_PLURAL_CATEGORIES.includes(keys[i + 1]);
+        if (nestingTerminalPluralCategory && hasPreservableNode(nextNode)) {
+          newNode.set('other', nextNode);
+        }
         current.set(key, newNode);
         current = newNode;
       } else {

--- a/src/utils/translation-updater/yaml-splicer.ts
+++ b/src/utils/translation-updater/yaml-splicer.ts
@@ -329,7 +329,11 @@ export function spliceYamlUpdate(
       }
       const keyColumn = lineStartColumnOf(source, range[0]);
       const serialized = serializeScalarValue(value, existingType, keyColumn, indentUnit);
-      patches.push({ start: range[0], end: range[1], text: serialized });
+      const gluedToColon = range[0] > 0 && source[range[0] - 1] === ':';
+      const leadingSeparator = gluedToColon ? ' ' : '';
+      const followedByComment = source[range[1]] === '#';
+      const trailingSeparator = followedByComment ? ' ' : '';
+      patches.push({ start: range[0], end: range[1], text: leadingSeparator + serialized + trailingSeparator });
       continue;
     }
 

--- a/src/utils/translation-utils.ts
+++ b/src/utils/translation-utils.ts
@@ -45,7 +45,7 @@ interface TranslationKeysResult {
   skippedKeys: Record<string, SkippedKeyDetails>;
 }
 
-export type TranslationPrimitiveValue = string | boolean | string[];
+export type TranslationPrimitiveValue = string | boolean | number | string[];
 
 export interface TranslationWithMetadata {
   value: TranslationPrimitiveValue;
@@ -87,7 +87,7 @@ interface SkippedKeyDetails {
  * Extract primitive value from any value type
  */
 function extractPrimitiveValue(value: unknown): TranslationPrimitiveValue {
-  if (Array.isArray(value) || typeof value === 'boolean' || typeof value === 'string') {
+  if (Array.isArray(value) || typeof value === 'boolean' || typeof value === 'string' || typeof value === 'number') {
     return value;
   }
 
@@ -137,6 +137,16 @@ export function findMissingTranslations(
     if (Array.isArray(entry)) return true;
     if (typeof entry === 'object') return 'value' in entry ? hasValue(entry.value) : true;
     return Boolean(entry);
+  };
+
+  // Presence check for non-string config scalars (numbers/booleans): a numeric `0`
+  // or boolean `false` counts as present, but `''`, null/undefined, and a blank
+  // metadata wrapper do not.
+  const hasConfigValue = (entry: any): boolean => {
+    if (entry === undefined || entry === null) return false;
+    if (typeof entry === 'object') return 'value' in entry ? hasConfigValue(entry.value) : false;
+    if (typeof entry === 'string') return entry.trim() !== '';
+    return true;
   };
 
   // Only an exactly-`["other"]` locale collapses a plural to a flat key.
@@ -199,9 +209,8 @@ export function findMissingTranslations(
       continue;
     }
 
-    if (typeof details === 'boolean') {
-      const targetValue = targetKeys[key];
-      if (targetValue === undefined || (typeof targetValue === 'object' && !('value' in targetValue))) {
+    if (typeof details === 'boolean' || typeof details === 'number') {
+      if (!hasConfigValue(targetKeys[key])) {
         missingKeys[key] = {
           value: details,
           sourceKey: key

--- a/tests/utils/translation-updater.test.js
+++ b/tests/utils/translation-updater.test.js
@@ -853,6 +853,111 @@ en:
       });
     });
 
+    describe('empty-key writing', () => {
+      it('inserts a space when filling a key that existed with an empty value', async () => {
+        const filePath = path.join(tempDir, 'devise.views.id.yml');
+        const initialContent = `id:
+  devise:
+    sessions:
+      already_signed_out:
+      new:
+        sign_in: Masuk
+`;
+        fs.writeFileSync(filePath, initialContent);
+
+        await updateTranslationFile(filePath, {
+          'devise.sessions.already_signed_out': 'Keluar dari akun berhasil.'
+        }, 'id');
+
+        const updated = fs.readFileSync(filePath, 'utf8');
+
+        expect(updated).toContain('already_signed_out: Keluar dari akun berhasil.');
+        expect(updated).not.toContain('already_signed_out:Keluar');
+
+        const reparsed = yaml.parse(updated);
+        expect(reparsed.id.devise.sessions.already_signed_out).toBe('Keluar dari akun berhasil.');
+        expect(reparsed.id.devise.sessions.new.sign_in).toBe('Masuk');
+      });
+
+      it('preserves an inline comment when filling an empty key', async () => {
+        const filePath = path.join(tempDir, 'commented.yml');
+        const initialContent = `en:
+  greeting: # please translate
+  other: value
+`;
+        fs.writeFileSync(filePath, initialContent);
+
+        await updateTranslationFile(filePath, { 'greeting': 'Hello' }, 'en');
+
+        const updated = fs.readFileSync(filePath, 'utf8');
+        const reparsed = yaml.parse(updated);
+
+        expect(reparsed.en.greeting).toBe('Hello');
+        expect(updated).toContain('# please translate');
+      });
+    });
+
+    describe('scalar-to-plural migration', () => {
+      it('preserves the original flat value as .other when nesting a plural category under it', async () => {
+        const filePath = path.join(tempDir, 'ja.yml');
+        const initialContent = `ja:
+  category_card:
+    sr:
+      show_description: '概要'
+    lessons_count: '%{count}レッスン'
+    select: '詳細を見る'
+`;
+        fs.writeFileSync(filePath, initialContent);
+
+        await updateTranslationFile(filePath, {
+          'category_card.lessons_count.zero': 'レッスンなし'
+        }, 'ja');
+
+        const updated = fs.readFileSync(filePath, 'utf8');
+        const reparsed = yaml.parse(updated);
+
+        expect(reparsed.ja.category_card.lessons_count.other).toBe('%{count}レッスン');
+        expect(reparsed.ja.category_card.lessons_count.zero).toBe('レッスンなし');
+        expect(reparsed.ja.category_card.select).toBe('詳細を見る');
+      });
+
+      it('preserves an existing sequence value as .other when nesting a plural category', async () => {
+        const filePath = path.join(tempDir, 'seq.yml');
+        const initialContent = `en:
+  count:
+    - one
+    - two
+`;
+        fs.writeFileSync(filePath, initialContent);
+
+        await updateTranslationFile(filePath, { 'count.zero': 'None' }, 'en');
+
+        const updated = fs.readFileSync(filePath, 'utf8');
+        const reparsed = yaml.parse(updated);
+
+        expect(reparsed.en.count.other).toEqual(['one', 'two']);
+        expect(reparsed.en.count.zero).toBe('None');
+      });
+
+      it('does not invent .other when a plural-category name is a non-terminal path segment', async () => {
+        const filePath = path.join(tempDir, 'settings.yml');
+        const initialContent = `en:
+  settings: old value
+`;
+        fs.writeFileSync(filePath, initialContent);
+
+        await updateTranslationFile(filePath, {
+          'settings.one.label': 'A label'
+        }, 'en');
+
+        const updated = fs.readFileSync(filePath, 'utf8');
+        const reparsed = yaml.parse(updated);
+
+        expect(reparsed.en.settings.other).toBeUndefined();
+        expect(reparsed.en.settings.one.label).toBe('A label');
+      });
+    });
+
     describe('multi-key deletion safety', () => {
       it('deleting all children of a nested map removes the parent without losing siblings', async () => {
         const filePath = path.join(tempDir, 'multi-delete.yml');

--- a/tests/utils/translation-utils.test.js
+++ b/tests/utils/translation-utils.test.js
@@ -44,6 +44,60 @@ describe('translation-utils', () => {
       expect(result.skippedKeys).toEqual({});
     });
 
+    it('does not treat an existing numeric 0 target value as missing', () => {
+      const sourceKeys = {
+        'number.format.precision': 2,
+        'number.format.significant': false
+      };
+      const targetKeys = {
+        'number.format.precision': 0,
+        'number.format.significant': false
+      };
+
+      const result = findMissingTranslations(sourceKeys, targetKeys);
+
+      expect(result.missingKeys).toEqual({});
+    });
+
+    it('reports a numeric source with a blank (null) target as missing without throwing', () => {
+      const sourceKeys = { 'number.format.precision': 2 };
+      const targetKeys = { 'number.format.precision': null };
+
+      const result = findMissingTranslations(sourceKeys, targetKeys);
+
+      expect(result.missingKeys['number.format.precision']).toEqual({
+        value: 2,
+        sourceKey: 'number.format.precision'
+      });
+    });
+
+    it('reports a boolean source with a blank (null) target as missing without throwing', () => {
+      const sourceKeys = { 'config.enabled': true };
+      const targetKeys = { 'config.enabled': null };
+
+      const result = findMissingTranslations(sourceKeys, targetKeys);
+
+      expect(result.missingKeys['config.enabled']).toEqual({
+        value: true,
+        sourceKey: 'config.enabled'
+      });
+    });
+
+    it.each([
+      ['empty-string target', ''],
+      ['blank metadata-wrapper target', { value: '' }]
+    ])('reports a numeric source with a %s as missing', (_, targetValue) => {
+      const sourceKeys = { 'number.format.precision': 2 };
+      const targetKeys = { 'number.format.precision': targetValue };
+
+      const result = findMissingTranslations(sourceKeys, targetKeys);
+
+      expect(result.missingKeys['number.format.precision']).toEqual({
+        value: 2,
+        sourceKey: 'number.format.precision'
+      });
+    });
+
     it.each([
       ['wip_ prefix', 'wip_feature', 'wip_This is a work in progress'],
       ['_wip suffix', 'feature', 'This is a work in progress_wip'],


### PR DESCRIPTION
- Empty existing key no longer glues the value to the colon (key:value → key: value).
- Inline comment on an empty key is preserved, not eaten by the value.
- Numeric config like precision: 0 is no longer treated as missing and overwritten.
- Migrating a flat key to a plural keeps the original value as .other instead of dropping it.
- Scalar-to-plural migration only triggers when the category is the terminal path segment.
- Existing sequence (array) values are preserved on plural migration, not destroyed.