### PR TITLE
Add property/fuzz tests for the YAML writer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@typescript-eslint/parser": "^8.44.0",
         "@typescript-eslint/typescript-estree": "^8.30.1",
         "eslint": "^8.57.1",
+        "fast-check": "^4.8.0",
         "globals": "^15.15.0",
         "jest": "^29.7.0",
         "ts-jest": "^29.4.4",
@@ -5008,6 +5009,46 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/fast-check": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.8.0.tgz",
+      "integrity": "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
+    "node_modules/fast-check/node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@typescript-eslint/parser": "^8.44.0",
     "@typescript-eslint/typescript-estree": "^8.30.1",
     "eslint": "^8.57.1",
+    "fast-check": "^4.8.0",
     "globals": "^15.15.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.4.4",

--- a/tests/utils/translation-updater.fuzz.test.js
+++ b/tests/utils/translation-updater.fuzz.test.js
@@ -1,0 +1,114 @@
+import { describe, it, expect } from '@jest/globals';
+import fc from 'fast-check';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import yaml from 'yaml';
+import { updateTranslationFile } from '../../src/utils/translation-updater/index.js';
+
+// Property/fuzz coverage for the two YAML-writer invariants whose input space
+// is too large to enumerate by example (the specific bug shapes from
+// 0.0.53/0.0.54 are pinned in translation-updater.test.js):
+//
+//   P1 — any supported value round-trips: write {k: v}, re-parse, get v back.
+//        Fuzzes the full scalar shape space (unicode, quotes, spaces, numbers,
+//        booleans, arrays, interpolation) where examples miss encoding edges.
+//   P2 — updating one leaf never alters any untouched key. Fuzzes the nested
+//        STRUCTURE (depth, breadth, neighbours) where adjacent-data loss hides.
+//
+// Oracle is SEMANTIC round-trip (re-parsed values), not byte equality — the
+// writer may legitimately re-quote a new value. Generators are scoped to the
+// SUPPORTED shapes; block literals, anchors, and multi-line plain scalars are
+// out of scope by design and intentionally not generated.
+
+const NUM_RUNS = 200;
+
+const leafValue = fc.oneof(
+  fc.string(),
+  fc.constantFrom('', '%{count} items', 'it\'s "quoted"', '  padded  ', 'café ☕'),
+  fc.integer({ min: -1000, max: 1000 }),
+  fc.constantFrom(0, -0.5, 3.14),
+  fc.boolean(),
+  fc.array(fc.string({ minLength: 1 }), { minLength: 1, maxLength: 4 })
+);
+
+const keySegment = fc
+  .string({ minLength: 1, maxLength: 6 })
+  .map((s) => s.replace(/[^a-zA-Z0-9_]/g, 'x'))
+  .filter((s) => s.length > 0);
+
+function nestedObject(depth) {
+  if (depth <= 0) return leafValue;
+  return fc.dictionary(keySegment, fc.oneof(leafValue, nestedObject(depth - 1)), {
+    minKeys: 1,
+    maxKeys: 4
+  });
+}
+
+function flattenLeaves(obj, prefix = '') {
+  const out = {};
+  for (const [k, v] of Object.entries(obj)) {
+    const key = prefix ? `${prefix}.${k}` : k;
+    if (v && typeof v === 'object' && !Array.isArray(v)) {
+      Object.assign(out, flattenLeaves(v, key));
+    } else {
+      out[key] = v;
+    }
+  }
+  return out;
+}
+
+async function withTempFile(fn) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'lh-fuzz-'));
+  try {
+    return await fn(path.join(dir, 'en.yml'));
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe('translation-updater (property/fuzz)', () => {
+  it('P1: a written value round-trips through re-parse for any supported shape', async () => {
+    await fc.assert(
+      fc.asyncProperty(keySegment, leafValue, async (key, value) => {
+        await withTempFile(async (filePath) => {
+          fs.writeFileSync(filePath, 'en:\n  seed: keep\n');
+          await updateTranslationFile(filePath, { [key]: value }, 'en');
+          const parsed = yaml.parse(fs.readFileSync(filePath, 'utf8')).en;
+          expect(parsed[key]).toEqual(value);
+          expect(parsed.seed).toBe('keep');
+        });
+      }),
+      { numRuns: NUM_RUNS }
+    );
+  });
+
+  it('P2: updating one leaf never alters the value of any untouched key', async () => {
+    await fc.assert(
+      fc.asyncProperty(nestedObject(2), leafValue, async (tree, newValue) => {
+        const leaves = flattenLeaves(tree);
+        const keys = Object.keys(leaves);
+        fc.pre(keys.length >= 2);
+
+        await withTempFile(async (filePath) => {
+          const doc = new yaml.Document();
+          doc.contents = doc.createNode({ en: tree });
+          fs.writeFileSync(filePath, doc.toString());
+
+          const before = yaml.parse(fs.readFileSync(filePath, 'utf8')).en;
+          const target = keys[0];
+          await updateTranslationFile(filePath, { [target]: newValue }, 'en');
+          const after = yaml.parse(fs.readFileSync(filePath, 'utf8')).en;
+
+          for (const key of keys.slice(1)) {
+            const segments = key.split('.');
+            const beforeVal = segments.reduce((o, s) => o?.[s], before);
+            const afterVal = segments.reduce((o, s) => o?.[s], after);
+            expect(afterVal).toEqual(beforeVal);
+          }
+        });
+      }),
+      { numRuns: NUM_RUNS }
+    );
+  });
+});


### PR DESCRIPTION
Adds two property-based tests (via `fast-check`, dev-only) for the YAML writer, covering the two invariants whose input space is too large to enumerate by example. The specific bug shapes from 0.0.53/0.0.54 stay pinned as explicit example tests.

- **P1 — value round-trip:** writing any supported value (`{k: v}`) and re-parsing yields `v`. Fuzzes the full scalar space (unicode, quotes, leading/trailing spaces, numbers incl. `0`, booleans incl. `false`, arrays, interpolation) where encoding edges hide.
- **P2 — no collateral damage:** updating one leaf never changes any untouched key. Fuzzes the nested structure (depth, breadth, neighbours) where adjacent-data loss hides.

Notes:
- Oracle is semantic round-trip (re-parsed values), not byte equality — the writer may legitimately re-quote a new value.
- Generators are scoped to supported shapes; block literals, anchors, and multi-line plain scalars are intentionally not generated.
- `fast-check` is a devDependency only (the published package ships `dist/` per the `files` whitelist).
- Verified both properties go red when their fix is reverted; ~1.3s runtime (200 runs each).

🤖 Generated with [Claude Code](https://claude.com/claude-code)