### PR TITLE
Fix empty msgid (and dropped msgctxt) when writing .po files

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -35,6 +35,16 @@ export interface TranslationWithMetadata {
   key: string;
   value: unknown;
   old_values?: Array<{ key: string }>;
+  metadata?: {
+    po_plural?: boolean;
+    plural_index?: number;
+    msgid?: string;
+    msgid_plural?: string;
+    translator_comments?: string;
+    source_references?: string[];
+    po_flags?: string[];
+    [key: string]: unknown;
+  };
 }
 
 /**

--- a/src/utils/po-utils.ts
+++ b/src/utils/po-utils.ts
@@ -277,8 +277,13 @@ export function createPoFile(entries: PoEntry[], headers?: Record<string, string
     }
 
     const translationEntry: any = {
+      msgid: entry.msgid,
       msgstr: entry.msgstr
     };
+
+    if (context) {
+      translationEntry.msgctxt = context;
+    }
 
     if (entry.msgid_plural) {
       translationEntry.msgid_plural = entry.msgid_plural;

--- a/src/utils/sync-service.ts
+++ b/src/utils/sync-service.ts
@@ -194,6 +194,7 @@ export const syncService: SyncService = {
             key: t.key,
             value: t.value,
             old_values: t.old_values,
+            metadata: t.metadata
           }));
         } else {
           const record: Record<string, string> = {};

--- a/src/utils/translation-processor.ts
+++ b/src/utils/translation-processor.ts
@@ -303,9 +303,18 @@ async function applyTranslations(
     console.log(chalk.blue(`  Updating translations for ${languageCode} in ${targetPath}`));
   }
 
+  const isPoFile = /\.(po|pot)$/i.test(targetPath);
+  const translationsToWrite = isPoFile
+    ? Object.entries(data.translations.data).map(([key, value]) => ({
+      key,
+      value,
+      ...(entry.keys[key]?.metadata && { metadata: entry.keys[key].metadata })
+    }))
+    : data.translations.data;
+
   const result = await translationUtils.updateTranslationFile(
     targetPath,
-    data.translations.data,
+    translationsToWrite,
     fileLocale,
     entry.path,
     undefined,

--- a/src/utils/translation-updater/po-handler.ts
+++ b/src/utils/translation-updater/po-handler.ts
@@ -1,8 +1,91 @@
 import { readFile, writeFile } from 'fs/promises';
 import { fileExists } from './common.js';
-import { parseUniqueKey, parsePoFile, createPoFile } from '../po-utils.js';
+import {
+  PLURAL_SUFFIX_REGEX,
+  parseUniqueKey,
+  parsePoFile,
+  createPoFile,
+  type PoEntry
+} from '../po-utils.js';
 import { surgicalUpdatePoFile } from '../po-surgical.js';
 import type { TranslationWithMetadata } from '../../types/index.js';
+
+const PLURAL_FORM_RULES: Record<string, string> = {
+  ar: 'nplurals=6; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5);',
+  be: 'nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);',
+  bs: 'nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);',
+  br: 'nplurals=5; plural=(n%10==1 && n%100!=11 && n%100!=71 && n%100!=91 ? 0 : n%10==2 && n%100!=12 && n%100!=72 && n%100!=92 ? 1 : (n%10==3 || n%10==4 || n%10==9) && (n%100<10 || n%100>19) && (n%100<70 || n%100>79) && (n%100<90 || n%100>99) ? 2 : n!=0 && n%1000000==0 ? 3 : 4);',
+  cs: 'nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 ? 1 : 2);',
+  cy: 'nplurals=4; plural=(n==1 ? 0 : n==2 ? 1 : n==8 || n==11 ? 2 : 3);',
+  ga: 'nplurals=5; plural=(n==1 ? 0 : n==2 ? 1 : n<7 ? 2 : n<11 ? 3 : 4);',
+  gd: 'nplurals=4; plural=(n==1 || n==11 ? 0 : n==2 || n==12 ? 1 : n>2 && n<20 ? 2 : 3);',
+  hr: 'nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);',
+  lt: 'nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 || n%100>=20) ? 1 : 2);',
+  lv: 'nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n!=0 ? 1 : 2);',
+  mk: 'nplurals=2; plural=(n==1 || n%10==1 ? 0 : 1);',
+  mt: 'nplurals=4; plural=(n==1 ? 0 : n==0 || (n%100>1 && n%100<11) ? 1 : n%100>10 && n%100<20 ? 2 : 3);',
+  pl: 'nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);',
+  ro: 'nplurals=3; plural=(n==1 ? 0 : n==0 || (n%100>0 && n%100<20) ? 1 : 2);',
+  ru: 'nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);',
+  sk: 'nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 ? 1 : 2);',
+  sl: 'nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3);',
+  sr: 'nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);',
+  uk: 'nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);'
+};
+
+const ONE_FORM_LANGUAGES = new Set([
+  'az', 'id', 'ja', 'ka', 'km', 'ko', 'lo', 'ms', 'my', 'th', 'tr', 'vi', 'zh'
+]);
+
+const TWO_FORM_LANGUAGES = new Set([
+  'af', 'am', 'bg', 'bn', 'ca', 'da', 'de', 'el', 'en', 'eo', 'es', 'et', 'eu',
+  'fa', 'fi', 'fo', 'gl', 'gu', 'he', 'hi', 'hu', 'hy', 'it', 'kn', 'ml', 'mn',
+  'mr', 'nb', 'ne', 'nl', 'nn', 'no', 'om', 'pa', 'pt', 'sq', 'sv', 'sw', 'ta',
+  'te', 'ti', 'ur', 'zu'
+]);
+
+function pluralFormsHeader(languageCode: string, requiredForms: number): string {
+  const normalized = languageCode.toLowerCase().replace('_', '-');
+  const base = normalized.split('-')[0];
+  let rule: string | undefined;
+
+  if (ONE_FORM_LANGUAGES.has(base)) rule = 'nplurals=1; plural=0;';
+  else if (base === 'fr' || normalized === 'pt-br') rule = 'nplurals=2; plural=(n > 1);';
+  else if (base === 'is') rule = 'nplurals=2; plural=(n%10!=1 || n%100==11);';
+  else if (PLURAL_FORM_RULES[base]) rule = PLURAL_FORM_RULES[base];
+  else if (TWO_FORM_LANGUAGES.has(base)) rule = 'nplurals=2; plural=(n != 1);';
+
+  if (!rule) {
+    throw new Error(
+      `Cannot create plural PO file for unsupported locale '${languageCode}'. ` +
+      'Create the target file with a valid Plural-Forms header first.'
+    );
+  }
+  if (pluralFormCount(rule) < requiredForms) {
+    throw new Error(
+      `Plural metadata for locale '${languageCode}' contains ${requiredForms} forms, ` +
+      `but its Plural-Forms rule supports ${pluralFormCount(rule)}.`
+    );
+  }
+
+  return rule;
+}
+
+function pluralFormCount(header: string): number {
+  return Number(header.match(/nplurals=(\d+)/)?.[1] ?? 2);
+}
+
+function commentsFromMetadata(metadata: TranslationWithMetadata['metadata']): PoEntry['comments'] {
+  const references = Array.from(new Set(metadata?.source_references ?? []));
+  const flags = Array.from(new Set(metadata?.po_flags ?? []));
+  const comments = {
+    ...(references.length > 0 && { reference: references.join('\n') }),
+    ...(metadata?.translator_comments && { extracted: metadata.translator_comments }),
+    ...(flags.length > 0 && { flag: flags.join(', ') })
+  };
+
+  return Object.keys(comments).length > 0 ? comments : undefined;
+}
 
 /**
  * Updates a .po file with new translations
@@ -19,6 +102,7 @@ export async function updatePoFile(
 
   // Build keyMappings for PO versioning (old key → new key)
   const keyMappings: Record<string, string> = {};
+  const metadataByKey = new Map<string, TranslationWithMetadata['metadata']>();
   let stringTranslations: Record<string, string>;
 
   if (Array.isArray(translations)) {
@@ -27,6 +111,7 @@ export async function updatePoFile(
     for (const item of translations) {
       const value = typeof item.value === 'string' ? item.value : String(item.value);
       stringTranslations[item.key] = value;
+      metadataByKey.set(item.key, item.metadata);
 
       for (const oldValue of item.old_values ?? []) {
         keyMappings[oldValue.key] = item.key;
@@ -81,20 +166,77 @@ export async function updatePoFile(
       await writeFile(filePath, updatedContent, 'utf-8');
     } else {
       // Create minimal .po file structure
-      const entries = Object.entries(stringTranslations).map(([key, value]) => {
-        const { msgid, context } = parseUniqueKey(key);
-        return {
+      const hasPluralMetadata = Array.from(metadataByKey.values())
+        .some(metadata => metadata?.po_plural);
+      const requiredPluralForms = Math.max(
+        1,
+        ...Array.from(metadataByKey.values())
+          .filter(metadata => metadata?.po_plural)
+          .map(metadata => (metadata?.plural_index ?? 0) + 1)
+      );
+      const pluralHeader = hasPluralMetadata
+        ? pluralFormsHeader(languageCode, requiredPluralForms)
+        : undefined;
+      const nplurals = pluralHeader ? pluralFormCount(pluralHeader) : 1;
+      const entriesByKey = new Map<string, PoEntry>();
+      const pluralEntryKeys = new Set<string>();
+
+      for (const [key, value] of Object.entries(stringTranslations)) {
+        const metadata = metadataByKey.get(key);
+        const isPlural = metadata?.po_plural === true;
+        const baseKey = isPlural ? key.replace(PLURAL_SUFFIX_REGEX, '') : key;
+        const { msgid: parsedMsgid, context } = parseUniqueKey(baseKey);
+        const msgid = metadata?.msgid || parsedMsgid;
+
+        if (!isPlural) {
+          entriesByKey.set(baseKey, {
+            msgid,
+            msgstr: [value],
+            msgctxt: context,
+            comments: commentsFromMetadata(metadata)
+          });
+          continue;
+        }
+
+        pluralEntryKeys.add(baseKey);
+        const pluralIndex = metadata?.plural_index ?? Number(key.match(PLURAL_SUFFIX_REGEX)?.[0].match(/\d+$/)?.[0] ?? 0);
+        if (pluralIndex >= nplurals) {
+          throw new Error(
+            `Plural form index ${pluralIndex} for '${msgid}' exceeds the ${nplurals} forms ` +
+            `supported by locale '${languageCode}'.`
+          );
+        }
+        const existing = entriesByKey.get(baseKey);
+        const entry = existing ?? {
           msgid,
-          msgstr: [value],
+          msgstr: Array(nplurals).fill(''),
           msgctxt: context,
-          msgid_plural: undefined,
-          comments: undefined
+          msgid_plural: metadata?.msgid_plural,
+          comments: commentsFromMetadata(metadata)
         };
-      });
+        entry.msgstr[pluralIndex] = value;
+        if (metadata?.msgid_plural) {
+          entry.msgid_plural = metadata.msgid_plural;
+        }
+        entry.comments ||= commentsFromMetadata(metadata);
+        entriesByKey.set(baseKey, entry);
+      }
+
+      const entries = Array.from(entriesByKey.values());
+      for (const key of pluralEntryKeys) {
+        const entry = entriesByKey.get(key);
+        if (!entry?.msgid_plural) {
+          throw new Error(
+            `Cannot create plural PO entry for '${entry?.msgid ?? key}' without msgid_plural metadata.`
+          );
+        }
+      }
+      const hasPlurals = entries.some(entry => entry.msgid_plural);
 
       const headers = {
         'Content-Type': 'text/plain; charset=UTF-8',
-        'Language': languageCode
+        'Language': languageCode,
+        ...(hasPlurals && pluralHeader && { 'Plural-Forms': pluralHeader })
       };
 
       const poContent = createPoFile(entries, headers);

--- a/tests/utils/po-handler.test.js
+++ b/tests/utils/po-handler.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals
 import { promises as fs } from 'fs';
 import path from 'path';
 import os from 'os';
+import { execFileSync, spawnSync } from 'child_process';
 
 describe('po-handler', () => {
   let updatePoFile;
@@ -118,6 +119,188 @@ msgstr "Old translation"
   });
 
   describe('SyncTranslation array support', () => {
+    const msgfmtAvailable = spawnSync('msgfmt', ['--version']).status === 0;
+
+    it('preserves PO references, flags, and translator comments when creating a file', async () => {
+      const targetFilePath = path.join(tempDir, 'new-with-metadata.po');
+      const translations = [
+        {
+          key: 'Website',
+          value: 'Webbplats',
+          metadata: {
+            source_references: [
+              'activity/settings_views.py',
+              'chat/settings_views.py',
+              'activity/settings_views.py'
+            ],
+            po_flags: ['elixir-autogen', 'elixir-format', 'elixir-autogen'],
+            translator_comments: 'Shown in the site details'
+          }
+        }
+      ];
+
+      const result = await updatePoFile(targetFilePath, translations, 'sv');
+      const updatedContent = await fs.readFile(targetFilePath, 'utf-8');
+
+      expect(result.created).toBe(true);
+      expect(updatedContent).toContain('#. Shown in the site details');
+      expect(updatedContent).toContain('#: activity/settings_views.py');
+      expect(updatedContent).toContain('#: chat/settings_views.py');
+      expect(updatedContent).toContain('#, elixir-autogen, elixir-format');
+      expect(updatedContent).toContain('msgid "Website"');
+      expect(updatedContent).toContain('msgstr "Webbplats"');
+      expect(updatedContent.match(/activity\/settings_views\.py/g)).toHaveLength(1);
+    });
+
+    it('groups plural forms into one valid entry when creating a file', async () => {
+      const targetFilePath = path.join(tempDir, 'new-plural.po');
+      const translations = [
+        {
+          key: 'navigation|%(count)d item',
+          value: '%(count)d objekt',
+          metadata: {
+            po_plural: true,
+            plural_index: 0,
+            msgid_plural: '%(count)d items',
+            source_references: ['lib/cart.ex:10']
+          }
+        },
+        {
+          key: 'navigation|%(count)d item__plural_1',
+          value: '%(count)d objekt',
+          metadata: {
+            po_plural: true,
+            plural_index: 1,
+            msgid: '%(count)d item',
+            source_references: ['lib/cart.ex:10']
+          }
+        }
+      ];
+
+      await updatePoFile(targetFilePath, translations, 'sv');
+      const updatedContent = await fs.readFile(targetFilePath, 'utf-8');
+
+      expect(updatedContent).toContain('"Plural-Forms: nplurals=2; plural=(n != 1);\\n"');
+      expect(updatedContent).toContain('msgctxt "navigation"');
+      expect(updatedContent).toContain('msgid "%(count)d item"');
+      expect(updatedContent).toContain('msgid_plural "%(count)d items"');
+      expect(updatedContent).toContain('msgstr[0] "%(count)d objekt"');
+      expect(updatedContent).toContain('msgstr[1] "%(count)d objekt"');
+      expect(updatedContent).not.toContain('msgid "%(count)d item__plural_1"');
+      expect(updatedContent.match(/lib\/cart\.ex:10/g)).toHaveLength(1);
+      if (msgfmtAvailable) {
+        expect(() => execFileSync('msgfmt', ['--check', '-o', '/dev/null', targetFilePath])).not.toThrow();
+      }
+    });
+
+    it('uses authoritative msgid_plural metadata regardless of input order', async () => {
+      const targetFilePath = path.join(tempDir, 'reverse-order-plural.po');
+      const translations = [
+        {
+          key: '%d item__plural_1',
+          value: '%d items translated',
+          metadata: { po_plural: true, plural_index: 1, msgid: '%d item' }
+        },
+        {
+          key: '%d item',
+          value: '%d item translated',
+          metadata: { po_plural: true, plural_index: 0, msgid_plural: '%d items' }
+        }
+      ];
+
+      await updatePoFile(targetFilePath, translations, 'en');
+      const updatedContent = await fs.readFile(targetFilePath, 'utf-8');
+
+      expect(updatedContent).toContain('msgid "%d item"');
+      expect(updatedContent).toContain('msgid_plural "%d items"');
+      expect(updatedContent).not.toContain('msgid_plural "%d item"');
+    });
+
+    it('rejects sparse plural data without msgid_plural metadata', async () => {
+      const targetFilePath = path.join(tempDir, 'sparse-plural.po');
+      const translations = [{
+        key: '%d item__plural_1',
+        value: '%d items translated',
+        metadata: { po_plural: true, plural_index: 1, msgid: '%d item' }
+      }];
+
+      await expect(updatePoFile(targetFilePath, translations, 'en'))
+        .rejects
+        .toThrow("Cannot create plural PO entry for '%d item' without msgid_plural metadata");
+    });
+
+    it.each([
+      ['lt', 3, 'nplurals=3'],
+      ['ar', 6, 'nplurals=6'],
+      ['br', 5, 'nplurals=5']
+    ])('writes a valid %s catalog with %i plural forms', async (locale, formCount, header) => {
+      const targetFilePath = path.join(tempDir, `new-plural-${locale}.po`);
+      const translations = Array.from({ length: formCount }, (_, pluralIndex) => ({
+        key: pluralIndex === 0 ? '%d item' : `%d item__plural_${pluralIndex}`,
+        value: `%d translated form ${pluralIndex}`,
+        metadata: {
+          po_plural: true,
+          plural_index: pluralIndex,
+          ...(pluralIndex === 0
+            ? { msgid_plural: '%d items' }
+            : { msgid: '%d item' })
+        }
+      }));
+
+      await updatePoFile(targetFilePath, translations, locale);
+      const updatedContent = await fs.readFile(targetFilePath, 'utf-8');
+
+      expect(updatedContent).toContain(header);
+      expect(updatedContent.match(/msgstr\[\d+\]/g)).toHaveLength(formCount);
+      if (msgfmtAvailable) {
+        expect(() => execFileSync('msgfmt', ['--check', '-o', '/dev/null', targetFilePath])).not.toThrow();
+      }
+    });
+
+    it.each([
+      ['fr-CA', 'nplurals=2; plural=(n > 1);'],
+      ['is', 'nplurals=2; plural=(n%10!=1 || n%100==11);'],
+      ['mk', 'nplurals=2; plural=(n==1 || n%10==1 ? 0 : 1);']
+    ])('uses the locale-specific plural rule for %s', async (locale, header) => {
+      const targetFilePath = path.join(tempDir, `specific-plural-${locale}.po`);
+      const translations = [0, 1].map(pluralIndex => ({
+        key: pluralIndex === 0 ? '%d item' : '%d item__plural_1',
+        value: `%d translated form ${pluralIndex}`,
+        metadata: {
+          po_plural: true,
+          plural_index: pluralIndex,
+          ...(pluralIndex === 0
+            ? { msgid_plural: '%d items' }
+            : { msgid: '%d item' })
+        }
+      }));
+
+      await updatePoFile(targetFilePath, translations, locale);
+      const updatedContent = await fs.readFile(targetFilePath, 'utf-8');
+
+      expect(updatedContent).toContain(header);
+    });
+
+    it('refuses to invent a plural rule for an unsupported locale', async () => {
+      const targetFilePath = path.join(tempDir, 'unsupported-plural.po');
+      const translations = [
+        {
+          key: '%d item',
+          value: '%d first form',
+          metadata: { po_plural: true, plural_index: 0, msgid_plural: '%d items' }
+        },
+        {
+          key: '%d item__plural_1',
+          value: '%d second form',
+          metadata: { po_plural: true, plural_index: 1, msgid: '%d item' }
+        }
+      ];
+
+      await expect(updatePoFile(targetFilePath, translations, 'xx'))
+        .rejects
+        .toThrow("Cannot create plural PO file for unsupported locale 'xx'");
+    });
+
     it('should accept array of translations with metadata', async () => {
       const targetFilePath = path.join(tempDir, 'array-test.po');
       const existingContent = `msgid ""

--- a/tests/utils/po-utils.test.js
+++ b/tests/utils/po-utils.test.js
@@ -138,6 +138,39 @@ msgstr[1] "%(count)d items"
     });
   });
 
+  describe('createPoFile', () => {
+    it('writes the msgid for each entry (regression: empty msgid)', () => {
+      const content = createPoFile([
+        { msgid: 'Website', msgstr: ['Webbplats'] },
+        { msgid: 'should have %{count} items', msgstr: ['bör ha %{count} objekt'] }
+      ]);
+
+      expect(content).toContain('msgid "Website"');
+      expect(content).toContain('msgstr "Webbplats"');
+      expect(content).toContain('msgid "should have %{count} items"');
+      // No non-header entry should have a blank msgid paired with a real msgstr
+      expect(content).not.toMatch(/msgid ""\nmsgstr "Webbplats"/);
+    });
+
+    it('round-trips msgid and msgstr through parsePoFile', () => {
+      const content = createPoFile([{ msgid: 'Hello', msgstr: ['Hej'] }]);
+      const parsed = parsePoFile(content);
+
+      expect(parsed.entries).toHaveLength(1);
+      expect(parsed.entries[0].msgid).toBe('Hello');
+      expect(parsed.entries[0].msgstr).toEqual(['Hej']);
+    });
+
+    it('preserves msgctxt when writing', () => {
+      const content = createPoFile([
+        { msgid: 'May', msgstr: ['Maj'], msgctxt: 'ShortenedMonths' }
+      ]);
+
+      expect(content).toContain('msgctxt "ShortenedMonths"');
+      expect(content).toContain('msgid "May"');
+    });
+  });
+
   describe('poEntriesToApiFormat', () => {
     it('should convert simple entries to API format', () => {
       const entries = [

--- a/tests/utils/sync-service.test.js
+++ b/tests/utils/sync-service.test.js
@@ -542,7 +542,11 @@ describe('syncService', () => {
                     {
                       key: 'New key name',
                       value: 'New key name translated',
-                      old_values: [{ key: 'Old key name' }]
+                      old_values: [{ key: 'Old key name' }],
+                      metadata: {
+                        source_references: ['lib/example.ex:10'],
+                        po_flags: ['elixir-format']
+                      }
                     },
                     {
                       key: 'Unchanged key',
@@ -567,8 +571,21 @@ describe('syncService', () => {
       const translations = mockTranslationUpdater.updateTranslationFile.mock.calls[0][1];
       expect(Array.isArray(translations)).toBe(true);
       expect(translations).toEqual([
-        { key: 'New key name', value: 'New key name translated', old_values: [{ key: 'Old key name' }] },
-        { key: 'Unchanged key', value: 'Unchanged translation', old_values: undefined }
+        {
+          key: 'New key name',
+          value: 'New key name translated',
+          old_values: [{ key: 'Old key name' }],
+          metadata: {
+            source_references: ['lib/example.ex:10'],
+            po_flags: ['elixir-format']
+          }
+        },
+        {
+          key: 'Unchanged key',
+          value: 'Unchanged translation',
+          old_values: undefined,
+          metadata: undefined
+        }
       ]);
     });
 

--- a/tests/utils/translation-processor.test.js
+++ b/tests/utils/translation-processor.test.js
@@ -108,6 +108,61 @@ describe('translation-processor', () => {
       expect(result.uniqueKeysTranslated.has('welcome')).toBe(true);
     });
 
+    it('passes source metadata through when writing PO translations', async () => {
+      const batches = [{
+        sourceFilePath: 'locales/en/messages.po',
+        sourceFile: {
+          path: 'locales/en/messages.po',
+          format: 'po',
+          content: Buffer.from('{}').toString('base64')
+        },
+        localeEntries: ['de:locales/en/messages.po'],
+        locales: ['de']
+      }];
+      const metadata = {
+        source_references: ['activity/settings_views.py', 'chat/settings_views.py'],
+        po_flags: ['elixir-autogen', 'elixir-format'],
+        translator_comments: 'Settings label'
+      };
+      const missingByLocale = {
+        'de:locales/en/messages.po': {
+          locale: 'de',
+          path: 'locales/en/messages.po',
+          targetPath: 'locales/de/messages.po',
+          keys: {
+            Website: { value: 'Website', sourceKey: 'Website', metadata }
+          },
+          keyCount: 1
+        }
+      };
+
+      mockTranslationUtils.createTranslationJob.mockResolvedValue({
+        jobs: [{ id: 'job-po', language: { code: 'de' } }]
+      });
+      mockTranslationUtils.checkJobStatus.mockResolvedValue({
+        status: 'completed',
+        translations: { data: { Website: 'Website' } },
+        language: { code: 'de' }
+      });
+
+      await processTranslationBatches(
+        batches,
+        missingByLocale,
+        { projectId: 'test-project' },
+        false,
+        { console: mockConsole, translationUtils: mockTranslationUtils }
+      );
+
+      expect(mockTranslationUtils.updateTranslationFile).toHaveBeenCalledWith(
+        'locales/de/messages.po',
+        [{ key: 'Website', value: 'Website', metadata }],
+        'de',
+        'locales/en/messages.po',
+        undefined,
+        { projectId: 'test-project' }
+      );
+    });
+
     it('handles a benign empty-jobs no-op without error (#432)', async () => {
       const batches = [{
         sourceFilePath: 'locales/en.json',


### PR DESCRIPTION
## What

`createPoFile` produced `.po` entries with an **empty `msgid`** and a populated `msgstr`, corrupting generated files:

```
msgid ""
msgstr "Viele Grüße"
```

Root cause: the function keyed each entry by msgid in the `translations` map but never set the `msgid` property **on the entry object**. `gettext-parser`'s `compile` reads msgid from that property, not the map key, so every entry serialized as `msgid ""`. `msgctxt` had the identical defect (used only as the grouping key, never written), silently dropping context disambiguation.
