### PR TITLE
Carry source references into newly created .po files (ci/export path)

### DIFF
--- a/src/commands/ci.ts
+++ b/src/commands/ci.ts
@@ -170,9 +170,19 @@ async function runSyncMode(
       console.log(chalk.gray(`  Updating ${file.path} (${file.language})...`));
     }
 
+    const isPoFile = /\.(po|pot)$/i.test(file.path);
+    const translations = isPoFile
+      ? file.translations.map(t => ({
+        key: t.key,
+        value: t.value,
+        old_values: t.old_values,
+        ...(t.file_references?.length && { metadata: { source_references: t.file_references } })
+      }))
+      : file.translations;
+
     await updateTranslationFile(
       file.path,
-      file.translations,
+      translations,
       file.language,
       undefined,
       config.sourceLocale,

--- a/tests/commands/ci.test.ts
+++ b/tests/commands/ci.test.ts
@@ -537,5 +537,49 @@ describe('ci command', () => {
 
       expect(deps.githubUtils.autoCommitSyncChanges).toHaveBeenCalledTimes(1);
     });
+
+    it('maps file_references to metadata.source_references for .po files', async () => {
+      mockEnv.LOCALHERO_SYNC_ID = 'sync_abc';
+      mockConfigUtils.getValidProjectConfig = jest.fn().mockResolvedValue({
+        projectId: 'test-project',
+        sourceLocale: 'en',
+        outputLocales: ['pl'],
+        translationFiles: { paths: ['locales/'] }
+      });
+      mockConfigUtils.saveProjectConfig = jest.fn().mockResolvedValue(undefined);
+
+      const deps = {
+        console: mockConsole,
+        configUtils: mockConfigUtils,
+        authUtils: mockAuthUtils,
+        githubUtils: { ...mockGithubUtils, autoCommitSyncChanges: jest.fn().mockResolvedValue(undefined) },
+        env: mockEnv,
+        translateCommand: mockTranslateCommand,
+        syncApi: {
+          getSyncTranslations: jest.fn().mockResolvedValue({
+            sync: {
+              sync_id: 'sync_abc', status: 'completed', created_at: '2026-04-23T00:00:00Z',
+              sync_url: 'https://example.com/sync', branch_name: 'localhero/sync', modified_keys_count: 1,
+              files: [{
+                path: 'locales/pl/LC_MESSAGES/messages.po',
+                language: 'pl',
+                translations: [{
+                  key: 'Website', name: 'Website', value: 'Witryna',
+                  file_references: ['lib/web.ex:10'], updated_at: '2026-04-23T00:00:00Z'
+                }]
+              }]
+            },
+            pagination: { current_page: 1, total_pages: 1, total_count: 1, next_page: null, prev_page: null, items_per_page: 500 }
+          }),
+          completeSyncUpdate: jest.fn().mockResolvedValue({ success: true })
+        },
+        updateTranslationFile: jest.fn().mockResolvedValue(undefined)
+      };
+
+      await ci({ skipCommit: true }, deps);
+
+      const passedTranslations = deps.updateTranslationFile.mock.calls[0][1];
+      expect(passedTranslations[0].metadata?.source_references).toEqual(['lib/web.ex:10']);
+    });
   });
 });


### PR DESCRIPTION
## What

When **Export-to-GitHub** (the `ci` sync path) creates a **brand-new** target `.po` file, the gettext `#: src/...` source-reference comments were dropped. Existing files were fine.

## Root cause

The `ci` command passes `SyncTranslation` objects straight to `updateTranslationFile`. The server sends references as a top-level `file_references` field, but `updatePoFile`'s create branch reads `metadata.source_references`. The two never connected, so for new files (which build entries from metadata, unlike the surgical in-place path) the references were silently lost.

Fix: map `file_references → metadata.source_references` for `.po`/`.pot` files in `ci`, mirroring what `sync-service.ts` already does.

## Verification

- Server-side (prod, read-only): refs are stored and sent — `lingui-test` 21/21 keys, `Kundo` 3608/3739.
- New `ci.test.ts` test asserts the mapping; fails without the fix, passes with it.
- 852 tests pass, build + lint clean.

## Context

Separate from the empty-msgid corruption fix (PR #40, merged). That fixed corrupt output; this restores the `#:` references on freshly-created locale files, which gettext tooling (`msgmerge`) and translators rely on. Surfaced while verifying the empty-msgid fix end-to-end on a real Export-to-GitHub PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)