### PR TITLE
Write #: source references when adding entries to existing .po files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.57] - 2026-06-23
+
+### Fixed
+- Entries added to an existing `.po` file during Export to GitHub now include their `#:` source-reference comments. Previously references were only written for brand-new files (0.0.56); when a new key was added to a locale file that already existed, the reference was dropped.
+
 ## [0.0.56] - 2026-06-23
 
 ### Fixed

--- a/src/utils/po-surgical.ts
+++ b/src/utils/po-surgical.ts
@@ -13,6 +13,7 @@ export function surgicalUpdatePoFile(
     targetLanguage?: string;
     sourceContent?: string;
     keyMappings?: Record<string, string>; // Map of old keys to new keys (for PO versioning)
+    references?: Record<string, string[]>; // uniqueKey -> source references (#: lines)
   }
 ): string {
   // If keyMappings are provided, skip the allIdentical optimization
@@ -263,6 +264,7 @@ function processLineByLine(
     targetLanguage?: string;
     sourceContent?: string;
     keyMappings?: Record<string, string>;
+    references?: Record<string, string[]>;
   }
 ): string {
   const lines = content.split('\n');
@@ -625,7 +627,7 @@ function addNewEntries(
   translations: Record<string, string>,
   parsed: any,
   existingChanges: Map<string, string>,
-  options?: { sourceLanguage?: string; targetLanguage?: string; sourceContent?: string }
+  options?: { sourceLanguage?: string; targetLanguage?: string; sourceContent?: string; references?: Record<string, string[]> }
 ): string[] {
   const result: string[] = [];
   const updatedTranslations = new Set<string>();
@@ -658,7 +660,7 @@ function addNewEntries(
         return;
       }
 
-      result.push(...createNewEntry(msgid, value, context));
+      result.push(...createNewEntry(msgid, value, context, options?.references?.[uniqueKey]));
       updatedTranslations.add(uniqueKey);
     }
   });
@@ -706,7 +708,7 @@ function addNewEntries(
       // Extract nplurals from the target file's headers
       const targetNplurals = extractNPlurals(parsed.headers || {});
 
-      result.push(...createNewPluralEntry(msgid, msgid_plural, pluralData, context, targetNplurals));
+      result.push(...createNewPluralEntry(msgid, msgid_plural, pluralData, context, targetNplurals, options?.references?.[uniqueKey]));
 
       // Mark all plural keys as updated
       updatedTranslations.add(uniqueKey);
@@ -724,10 +726,12 @@ function addNewEntries(
 /**
  * Create a new regular translation entry
  */
-function createNewEntry(msgid: string, msgstr: string, context?: string): string[] {
+function createNewEntry(msgid: string, msgstr: string, context?: string, references?: string[]): string[] {
   const result: string[] = [];
 
   result.push('');
+
+  pushReferenceComments(result, references);
 
   if (context) {
     result.push(`msgctxt "${escapePoString(context)}"`);
@@ -739,6 +743,15 @@ function createNewEntry(msgid: string, msgstr: string, context?: string): string
   return result;
 }
 
+function pushReferenceComments(result: string[], references?: string[]): void {
+  if (!references?.length) {
+    return;
+  }
+  for (const reference of Array.from(new Set(references))) {
+    result.push(`#: ${reference}`);
+  }
+}
+
 /**
  * Create a new plural translation entry
  */
@@ -747,11 +760,14 @@ function createNewPluralEntry(
   msgid_plural: string,
   translations: string[],
   context?: string,
-  nplurals: number = 2
+  nplurals: number = 2,
+  references?: string[]
 ): string[] {
   const result: string[] = [];
 
   result.push('');
+
+  pushReferenceComments(result, references);
 
   if (context) {
     result.push(`msgctxt "${escapePoString(context)}"`);

--- a/src/utils/translation-updater/po-handler.ts
+++ b/src/utils/translation-updater/po-handler.ts
@@ -87,6 +87,19 @@ function commentsFromMetadata(metadata: TranslationWithMetadata['metadata']): Po
   return Object.keys(comments).length > 0 ? comments : undefined;
 }
 
+function referencesByKey(
+  metadataByKey: Map<string, TranslationWithMetadata['metadata']>
+): Record<string, string[]> {
+  const references: Record<string, string[]> = {};
+  for (const [key, metadata] of metadataByKey) {
+    const refs = metadata?.source_references;
+    if (refs?.length) {
+      references[key] = refs;
+    }
+  }
+  return references;
+}
+
 /**
  * Updates a .po file with new translations
  */
@@ -143,7 +156,8 @@ export async function updatePoFile(
       sourceLanguage,
       targetLanguage: languageCode,
       sourceContent,
-      keyMappings: hasKeyMappings ? keyMappings : undefined
+      keyMappings: hasKeyMappings ? keyMappings : undefined,
+      references: referencesByKey(metadataByKey)
     });
 
     if (updatedContent !== originalContent) {

--- a/tests/helpers/assert-valid-po.js
+++ b/tests/helpers/assert-valid-po.js
@@ -1,0 +1,86 @@
+/**
+ * Dependency-free structural assertions for generated .po content.
+ *
+ * These run everywhere (no gettext/msgfmt required) and exist to catch the
+ * class of bugs that substring assertions miss: empty msgids, duplicate
+ * definitions, and malformed plural entries. The empty-msgid and duplicate
+ * checks work on raw text on purpose, the PO parser collapses/skips these, so
+ * a corrupt `msgid ""` paired with a real msgstr would otherwise be invisible.
+ */
+
+import { parsePoFile } from '../../src/utils/po-utils.js';
+
+/**
+ * Split .po content into raw entry blocks (keeping comment lines).
+ * Block 0 is the header (the legitimate `msgid ""`).
+ */
+function rawEntries(content) {
+  return content
+    .split(/\n\s*\n/)
+    .map((block) => block.trim())
+    .filter((block) => block.length > 0 && /(^|\n)msgid /.test(block));
+}
+
+function msgidOf(block) {
+  const match = block.match(/(^|\n)msgid "((?:[^"\\]|\\.)*)"/);
+  return match ? match[2] : null;
+}
+
+function msgctxtOf(block) {
+  const match = block.match(/(^|\n)msgctxt "((?:[^"\\]|\\.)*)"/);
+  return match ? match[2] : null;
+}
+
+/**
+ * Assert that generated .po content is structurally valid.
+ * Returns the parsed file so callers can make further assertions.
+ */
+export function assertValidPo(content, { allowEmpty = false } = {}) {
+  if (typeof content !== 'string' || content.trim() === '') {
+    throw new Error('assertValidPo: content is empty');
+  }
+
+  const blocks = rawEntries(content);
+  const seen = new Set();
+
+  blocks.forEach((block, index) => {
+    if (index === 0) return; // header is the one legitimate `msgid ""`
+
+    // 1. No non-header entry may have an empty msgid (the corruption bug).
+    //    Raw-text check: po.parse silently drops these.
+    if (msgidOf(block) === '') {
+      throw new Error(`assertValidPo: entry #${index} has an empty msgid:\n${block}`);
+    }
+
+    // 2. No duplicate msgid+msgctxt. Raw-text check: po.parse collapses
+    //    duplicates (last wins), so a parsed-entry check would never see them.
+    const key = `${msgctxtOf(block) ?? ''} ${msgidOf(block)}`;
+    if (seen.has(key)) {
+      throw new Error(`assertValidPo: duplicate entry (msgctxt+msgid):\n${block}`);
+    }
+    seen.add(key);
+  });
+
+  // 3. The file must re-parse without throwing.
+  let parsed;
+  try {
+    parsed = parsePoFile(content);
+  } catch (error) {
+    throw new Error(`assertValidPo: content does not parse: ${error.message}`);
+  }
+
+  if (!allowEmpty && parsed.entries.length === 0) {
+    throw new Error('assertValidPo: no translation entries found');
+  }
+
+  // 4. Plural entries must have msgid_plural and at least one msgstr form.
+  for (const entry of parsed.entries) {
+    if (entry.msgid_plural && (!Array.isArray(entry.msgstr) || entry.msgstr.length === 0)) {
+      throw new Error(
+        `assertValidPo: plural entry for msgid=${JSON.stringify(entry.msgid)} has no msgstr forms`
+      );
+    }
+  }
+
+  return parsed;
+}

--- a/tests/helpers/assert-valid-po.test.js
+++ b/tests/helpers/assert-valid-po.test.js
@@ -1,0 +1,72 @@
+import { assertValidPo } from './assert-valid-po.js';
+
+const HEADER = `msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=utf-8\\n"
+"Language: sv\\n"
+`;
+
+describe('assertValidPo', () => {
+  it('passes for a well-formed file', () => {
+    const content = `${HEADER}
+#: src/App.jsx:1
+msgid "Hello"
+msgstr "Hej"
+`;
+    expect(() => assertValidPo(content)).not.toThrow();
+  });
+
+  it('catches the empty-msgid corruption bug', () => {
+    // Exactly what the createPoFile bug produced: blank msgid, real msgstr.
+    const content = `${HEADER}
+msgid ""
+msgstr "Hej"
+`;
+    expect(() => assertValidPo(content)).toThrow(/empty msgid/);
+  });
+
+  it('catches multiple empty-msgid entries', () => {
+    const content = `${HEADER}
+msgid ""
+msgstr "Webbplats"
+
+msgid ""
+msgstr "Stäng"
+`;
+    expect(() => assertValidPo(content)).toThrow(/empty msgid/);
+  });
+
+  it('accepts the single legitimate header msgid ""', () => {
+    const content = `${HEADER}
+msgid "Save"
+msgstr "Spara"
+`;
+    expect(() => assertValidPo(content)).not.toThrow();
+  });
+
+  it('catches duplicate msgid+msgctxt', () => {
+    const content = `${HEADER}
+msgid "Save"
+msgstr "Spara"
+
+msgid "Save"
+msgstr "Lagra"
+`;
+    expect(() => assertValidPo(content)).toThrow(/duplicate/);
+  });
+
+  it('passes a plural entry with msgid_plural and forms', () => {
+    const content = `${HEADER}"Plural-Forms: nplurals=2; plural=(n != 1);\\n"
+
+msgid "one item"
+msgid_plural "%d items"
+msgstr[0] "en sak"
+msgstr[1] "%d saker"
+`;
+    expect(() => assertValidPo(content)).not.toThrow();
+  });
+
+  it('throws on empty content', () => {
+    expect(() => assertValidPo('')).toThrow(/empty/);
+  });
+});

--- a/tests/utils/po-handler.test.js
+++ b/tests/utils/po-handler.test.js
@@ -3,6 +3,7 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import os from 'os';
 import { execFileSync, spawnSync } from 'child_process';
+import { assertValidPo } from '../helpers/assert-valid-po.js';
 
 describe('po-handler', () => {
   let updatePoFile;
@@ -52,6 +53,7 @@ msgstr "Hello"
 
       const targetContent = await fs.readFile(targetFilePath, 'utf-8');
 
+      assertValidPo(targetContent);
       expect(targetContent).toContain('"Language: \\n"');
       expect(targetContent).not.toContain('"Language: sv\\n"');
       expect(targetContent).toContain('msgstr "Hej"');
@@ -180,6 +182,7 @@ msgstr "Old translation"
       await updatePoFile(targetFilePath, translations, 'sv');
       const updatedContent = await fs.readFile(targetFilePath, 'utf-8');
 
+      assertValidPo(updatedContent);
       expect(updatedContent).toContain('"Plural-Forms: nplurals=2; plural=(n != 1);\\n"');
       expect(updatedContent).toContain('msgctxt "navigation"');
       expect(updatedContent).toContain('msgid "%(count)d item"');
@@ -250,6 +253,7 @@ msgstr "Old translation"
       await updatePoFile(targetFilePath, translations, locale);
       const updatedContent = await fs.readFile(targetFilePath, 'utf-8');
 
+      assertValidPo(updatedContent);
       expect(updatedContent).toContain(header);
       expect(updatedContent.match(/msgstr\[\d+\]/g)).toHaveLength(formCount);
       if (msgfmtAvailable) {

--- a/tests/utils/po-surgical.test.js
+++ b/tests/utils/po-surgical.test.js
@@ -1,6 +1,7 @@
 import { jest } from '@jest/globals';
 import { readFileSync } from 'fs';
 import { join } from 'path';
+import { assertValidPo } from '../helpers/assert-valid-po.js';
 
 describe('po-surgical', () => {
   let surgicalUpdatePoFile;
@@ -496,6 +497,7 @@ msgstr "Befintlig"
         references: { 'This is the title of our website.': ['src/components/Header.jsx:11'] }
       });
 
+      assertValidPo(result);
       expect(result).toContain('#: src/components/Header.jsx:11');
       expect(result).toContain('msgid "This is the title of our website."');
       expect(result).toContain('msgstr "Det här är titeln på vår webbplats."');

--- a/tests/utils/po-surgical.test.js
+++ b/tests/utils/po-surgical.test.js
@@ -479,6 +479,63 @@ msgstr "annan"`;
     });
   });
 
+  describe('Source References on New Entries', () => {
+    test('writes #: source references when adding a new entry to an existing file', () => {
+      const original = `msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=utf-8\\n"
+
+msgid "Existing"
+msgstr "Befintlig"
+`;
+      const translations = { 'This is the title of our website.': 'Det här är titeln på vår webbplats.' };
+
+      const result = surgicalUpdatePoFile(original, translations, {
+        sourceLanguage: 'en',
+        targetLanguage: 'sv',
+        references: { 'This is the title of our website.': ['src/components/Header.jsx:11'] }
+      });
+
+      expect(result).toContain('#: src/components/Header.jsx:11');
+      expect(result).toContain('msgid "This is the title of our website."');
+      expect(result).toContain('msgstr "Det här är titeln på vår webbplats."');
+    });
+
+    test('writes one #: line per reference and de-duplicates', () => {
+      const original = `msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=utf-8\\n"
+`;
+      const translations = { 'Save': 'Spara' };
+
+      const result = surgicalUpdatePoFile(original, translations, {
+        sourceLanguage: 'en',
+        targetLanguage: 'sv',
+        references: { 'Save': ['a.ex:1', 'b.ex:2', 'a.ex:1'] }
+      });
+
+      expect(result).toContain('#: a.ex:1');
+      expect(result).toContain('#: b.ex:2');
+      expect(result.match(/#: a\.ex:1/g)).toHaveLength(1);
+    });
+
+    test('omits #: line when no references provided', () => {
+      const original = `msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=utf-8\\n"
+`;
+      const translations = { 'Save': 'Spara' };
+
+      const result = surgicalUpdatePoFile(original, translations, {
+        sourceLanguage: 'en',
+        targetLanguage: 'sv'
+      });
+
+      expect(result).toContain('msgid "Save"');
+      expect(result).not.toContain('#:');
+    });
+  });
+
   describe('Source Content msgid_plural Lookup', () => {
     test('should use sourceContent to find proper msgid_plural when creating new plural entries', () => {
       const sourceContent = `msgid ""

--- a/tests/utils/po-utils.test.js
+++ b/tests/utils/po-utils.test.js
@@ -1,6 +1,7 @@
 import { jest } from '@jest/globals';
 import { readFileSync } from 'fs';
 import { join } from 'path';
+import { assertValidPo } from '../helpers/assert-valid-po.js';
 
 const loadFixture = (name) => {
   const fixturePath = join(process.cwd(), 'tests', 'fixtures', 'po', `${name}.po`);
@@ -145,6 +146,7 @@ msgstr[1] "%(count)d items"
         { msgid: 'should have %{count} items', msgstr: ['bör ha %{count} objekt'] }
       ]);
 
+      assertValidPo(content);
       expect(content).toContain('msgid "Website"');
       expect(content).toContain('msgstr "Webbplats"');
       expect(content).toContain('msgid "should have %{count} items"');


### PR DESCRIPTION
## What

Completes the source-reference handling for Export to GitHub. PR #42 fixed `#:` references for **brand-new** `.po` files; this fixes them for entries **added to a file that already exists** (the surgical path).

