### PR TITLE
Separate appended .po entries with a single blank line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.58] - 2026-06-23
+
+### Fixed
+- New entries appended to an existing `.po` file are now separated by a single blank line instead of stacking up to three, and the file keeps exactly one trailing newline. Cosmetic only (the output was already valid), but it keeps Export-to-GitHub diffs clean.
+
 ## [0.0.57] - 2026-06-23
 
 ### Fixed

--- a/src/utils/po-surgical.ts
+++ b/src/utils/po-surgical.ts
@@ -373,8 +373,7 @@ function processLineByLine(
     const newEntries = addNewEntries(translations, parsed, changesToMake, options);
     if (newEntries.length > 0) {
       const lines = content.split('\n');
-      lines.push('');
-      lines.push(...newEntries);
+      appendNewEntries(lines, newEntries);
       return lines.join('\n');
     }
     return content;
@@ -612,12 +611,23 @@ function processLineByLine(
   // Add new entries that don't exist in the original file
   const newEntries = addNewEntries(translations, parsed, changesToMake, options);
   if (newEntries.length > 0) {
-    // Add new entries at the end
-    result.push('');
-    result.push(...newEntries);
+    appendNewEntries(result, newEntries);
   }
 
   return result.join('\n');
+}
+
+/**
+ * Append new entries after existing content. New entries already start with
+ * their own blank-line separator, so trim trailing blanks first to avoid
+ * stacking multiple blank lines (a well-formed file ends with a newline).
+ */
+function appendNewEntries(lines: string[], newEntries: string[]): void {
+  while (lines.length > 0 && lines[lines.length - 1].trim() === '') {
+    lines.pop();
+  }
+  lines.push(...newEntries);
+  lines.push(''); // keep a single trailing newline after join('\n')
 }
 
 /**

--- a/tests/utils/po-surgical.test.js
+++ b/tests/utils/po-surgical.test.js
@@ -503,6 +503,28 @@ msgstr "Befintlig"
       expect(result).toContain('msgstr "Det här är titeln på vår webbplats."');
     });
 
+    test('separates appended entries with a single blank line (no extra padding)', () => {
+      const original = `msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=utf-8\\n"
+
+#: src/App.jsx:1
+msgid "Existing"
+msgstr "Befintlig"
+`;
+      const translations = { 'New one': 'Ny ett' };
+
+      const result = surgicalUpdatePoFile(original, translations, {
+        sourceLanguage: 'en',
+        targetLanguage: 'sv'
+      });
+
+      expect(result).not.toMatch(/\n\n\n/); // no triple newline (= 2+ blank lines)
+      expect(result).toContain('msgid "New one"');
+      expect(result.endsWith('\n')).toBe(true); // single trailing newline
+      expect(result.endsWith('\n\n')).toBe(false);
+    });
+
     test('writes one #: line per reference and de-duplicates', () => {
       const original = `msgid ""
 msgstr ""


### PR DESCRIPTION

When new entries are appended to an **existing** `.po` file (Export to GitHub adding a key to a locale that already exists), up to **three** blank lines stacked before the first new entry. Now it's a single blank line, with exactly one trailing newline preserved.
