### PR TITLE
Bring-your-own-translations PR ingestion

### DIFF
--- a/src/api/pull-request-imports.ts
+++ b/src/api/pull-request-imports.ts
@@ -1,0 +1,42 @@
+import { getApiKey } from '../utils/auth.js';
+import { getApiHost } from './client.js';
+import type { TargetChangeFile } from '../utils/target-changes.js';
+
+export interface PullRequestImportParams {
+  projectId: string;
+  branch: string;
+  jobGroupId: string;
+  files: TargetChangeFile[];
+}
+
+export interface PullRequestImportResponse {
+  imported_count: number;
+  skipped: Array<{ path: string; key: string; reason: string }>;
+  job_group?: { id: string; short_url: string };
+}
+
+export async function createPullRequestImport(
+  params: PullRequestImportParams
+): Promise<PullRequestImportResponse> {
+  const apiKey = await getApiKey();
+  const apiHost = getApiHost();
+
+  const response = await fetch(`${apiHost}/api/v1/projects/${params.projectId}/pull_request_imports`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${apiKey}`
+    },
+    body: JSON.stringify({
+      branch: params.branch,
+      job_group_id: params.jobGroupId,
+      files: params.files
+    })
+  });
+
+  if (!response.ok) {
+    throw new Error(`Translation ingestion failed with status ${response.status}`);
+  }
+
+  return response.json() as Promise<PullRequestImportResponse>;
+}

--- a/src/api/translations.ts
+++ b/src/api/translations.ts
@@ -1,7 +1,7 @@
 import { getApiKey } from '../utils/auth.js';
 import { apiRequest, getApiHost } from './client.js';
 import { getCurrentBranch } from '../utils/git.js';
-import type { KeyIdentifier } from '../types/index.js';
+import type { KeyIdentifier, SkippedLanguage } from '../types/index.js';
 
 // Source file for translation
 export interface SourceFile {
@@ -36,6 +36,7 @@ export interface TranslationJobsResponse {
     id: string;
     short_url: string;
   };
+  skipped_languages?: SkippedLanguage[];
 }
 
 /**
@@ -71,7 +72,8 @@ export async function createTranslationJob(params: CreateTranslationJobParams): 
   return {
     jobs: response.jobs,
     totalJobs: response.jobs.length,
-    ...(response.job_group && { job_group: response.job_group })
+    ...(response.job_group && { job_group: response.job_group }),
+    ...(response.skipped_languages && { skipped_languages: response.skipped_languages })
   };
 }
 

--- a/src/commands/translate.ts
+++ b/src/commands/translate.ts
@@ -23,6 +23,8 @@ import {
   MissingLocaleEntry
 } from '../utils/translation-utils.js';
 import { autoCommitChanges } from '../utils/github.js';
+import { detectTargetChanges, type TargetChangeFile } from '../utils/target-changes.js';
+import { createPullRequestImport } from '../api/pull-request-imports.js';
 import { processTranslationBatches } from '../utils/translation-processor.js';
 import { createIgnoreMatcher, summarizeRemoved } from '../utils/ignore-keys.js';
 import { logIgnoreSummary } from '../utils/ignore-keys-logging.js';
@@ -248,6 +250,36 @@ export async function translate(options: TranslationOptions = {}, deps: Translat
 
   const projectId = config.projectId;
 
+  async function sendPullRequestImport(
+    targetChanges: TargetChangeFile[],
+    jobGroupId: string
+  ): Promise<void> {
+    if (targetChanges.length === 0) return;
+
+    try {
+      const branch = await getCurrentBranch();
+      if (!branch) return;
+
+      const importResult = await createPullRequestImport({
+        projectId,
+        branch,
+        jobGroupId,
+        files: targetChanges
+      });
+
+      if (importResult.imported_count > 0) {
+        console.log(`» Sent ${importResult.imported_count} translation value${importResult.imported_count === 1 ? '' : 's'} from this PR for review`);
+      }
+      for (const skipped of importResult.skipped) {
+        console.log(chalk.yellow(`  Skipped ${skipped.path}: ${skipped.key} (${skipped.reason})`));
+      }
+    } catch (err) {
+      if (verbose) {
+        console.log(chalk.dim(`Translation ingestion skipped: ${(err as Error).message}`));
+      }
+    }
+  }
+
   async function sendFinalize(
     manifest: Record<string, any>,
     jobGroupId: string,
@@ -301,9 +333,11 @@ export async function translate(options: TranslationOptions = {}, deps: Translat
   // This is the complete snapshot of "what differs from main" for this push.
   let manifest: Record<string, any> | null = null;
   let removedManifest: Record<string, any> | null = null;
+  let targetChanges: TargetChangeFile[] = [];
   if (options.changedOnly) {
     manifest = getManifestForFinalize(sourceFiles, config, !!verbose);
     removedManifest = getRemovedKeysManifestForFinalize(sourceFiles, config, !!verbose);
+    targetChanges = detectTargetChanges(sourceFiles, targetFilesByLocale, config, !!verbose) ?? [];
 
     const filtered = filterByGitChanges(
       sourceFiles,
@@ -314,9 +348,11 @@ export async function translate(options: TranslationOptions = {}, deps: Translat
 
     if (filtered !== null) {
       if (Object.keys(filtered).length === 0) {
+        const jobGroupId = nanoid();
         if (manifest !== null) {
-          await sendFinalize(manifest, nanoid(), removedManifest);
+          await sendFinalize(manifest, jobGroupId, removedManifest);
         }
+        await sendPullRequestImport(targetChanges, jobGroupId);
         console.log(chalk.green('✓ All changed keys are already translated'));
         return;
       }
@@ -381,6 +417,14 @@ export async function translate(options: TranslationOptions = {}, deps: Translat
 
     if (manifest !== null) {
       await sendFinalize(manifest, jobGroupId, removedManifest);
+    }
+
+    await sendPullRequestImport(targetChanges, jobGroupId);
+
+    const translatedLocales = new Set(translationResult.languages);
+    const onlySkipped = translationResult.skippedLanguages.filter((locale) => !translatedLocales.has(locale));
+    if (onlySkipped.length > 0) {
+      console.log(chalk.blue(`ℹ Auto-translation off for ${onlySkipped.join(', ')} (project setting)`));
     }
 
     await configUtils.updateLastSyncedAt();

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -180,6 +180,13 @@ export interface KeyIdentifier {
   context?: string;
 }
 
+// A target language the backend declined to auto-translate (e.g. auto_translate
+// disabled for the locale), reported in the translation job creation response.
+export interface SkippedLanguage {
+  code: string;
+  reason: string;
+}
+
 // Prunable key from API (for --prune functionality)
 export interface PrunableKey {
   id: string;

--- a/src/utils/git-changes.ts
+++ b/src/utils/git-changes.ts
@@ -233,7 +233,7 @@ export function getChangedKeysForProject(
 /**
  * Get base branch from config, environment, or default
  */
-function getBaseBranch(config: ProjectConfig): string {
+export function getBaseBranch(config: ProjectConfig): string {
   return config.translationFiles?.baseBranch
     || process.env.GITHUB_BASE_REF
     || 'main';
@@ -293,7 +293,7 @@ function resolveBranchRef(branch: string): string | null {
  * example on shallow clones where the real ancestor was pruned — so behavior
  * degrades to the pre-fix state rather than aborting `--changed-only`.
  */
-function resolveCompareRef(branch: string, verbose = false): string | null {
+export function resolveCompareRef(branch: string, verbose = false): string | null {
   const resolvedBase = resolveBranchRef(branch);
   if (!resolvedBase) return null;
 
@@ -319,7 +319,7 @@ function resolveCompareRef(branch: string, verbose = false): string | null {
   }
 }
 
-interface FileDiff {
+export interface FileDiff {
   oldFlat: Record<string, any>;
   newFlat: Record<string, any>;
 }
@@ -328,7 +328,7 @@ interface FileDiff {
  * Get the old (base branch) and new (working directory) flattened key maps for a file.
  * Returns null if the current file cannot be read/parsed (caller should skip).
  */
-function diffFileKeys(
+export function diffFileKeys(
   file: TranslationFile,
   resolvedRef: string,
   verbose: boolean

--- a/src/utils/target-changes.ts
+++ b/src/utils/target-changes.ts
@@ -1,0 +1,146 @@
+import chalk from 'chalk';
+import type { ProjectConfig, TranslationFile } from '../types/index.js';
+import {
+  isGitAvailable,
+  getBaseBranch,
+  resolveCompareRef,
+  diffFileKeys
+} from './git-changes.js';
+import { findTargetFile } from './translation-utils.js';
+
+export interface TargetChange {
+  key: string;
+  status: 'added' | 'updated';
+  value: string;
+  old_value?: string;
+}
+
+export interface TargetChangeFile {
+  path: string;
+  source_path: string;
+  locale: string;
+  format: string;
+  changes: TargetChange[];
+}
+
+const MAX_TOTAL_CHANGES = 1000;
+
+/**
+ * Detect target translations the PR adds or changes, by diffing each target
+ * file against the merge-base of the configured base branch. Powers the
+ * bring-your-own-translations flow (backend pull_request_imports endpoint).
+ *
+ * Returns null when git or the base branch is unavailable, or the change cap
+ * is exceeded (callers should skip ingestion). Returns [] when nothing changed.
+ */
+export function detectTargetChanges(
+  sourceFiles: TranslationFile[],
+  targetFilesByLocale: Record<string, TranslationFile[]>,
+  config: ProjectConfig,
+  verbose: boolean
+): TargetChangeFile[] | null {
+  if (!isGitAvailable()) {
+    return null;
+  }
+
+  const resolvedRef = resolveCompareRef(getBaseBranch(config), verbose);
+  if (!resolvedRef) {
+    return null;
+  }
+
+  const result: TargetChangeFile[] = [];
+  let totalChanges = 0;
+
+  for (const [locale, targetFiles] of Object.entries(targetFilesByLocale)) {
+    for (const targetFile of targetFiles) {
+      const changes = detectFileChanges(targetFile, resolvedRef, verbose);
+      if (changes.length === 0) continue;
+
+      totalChanges += changes.length;
+      if (totalChanges > MAX_TOTAL_CHANGES) {
+        if (verbose) {
+          console.log(chalk.yellow(`Skipping translation ingestion: more than ${MAX_TOTAL_CHANGES} changed target values`));
+        }
+        return null;
+      }
+
+      const sourcePath = sourcePathFor(targetFile, locale, sourceFiles, targetFiles, config);
+      if (!sourcePath) {
+        if (verbose) {
+          console.log(chalk.dim(`  ${targetFile.path}: no matching source file, skipping ingestion`));
+        }
+        continue;
+      }
+
+      result.push({
+        path: targetFile.path,
+        source_path: sourcePath,
+        locale,
+        format: targetFile.format,
+        changes
+      });
+    }
+  }
+
+  return result;
+}
+
+function detectFileChanges(
+  targetFile: TranslationFile,
+  resolvedRef: string,
+  verbose: boolean
+): TargetChange[] {
+  try {
+    const diff = diffFileKeys(targetFile, resolvedRef, verbose);
+    if (!diff) return [];
+
+    const { oldFlat, newFlat } = diff;
+    const changes: TargetChange[] = [];
+
+    for (const [key, value] of Object.entries(newFlat)) {
+      if (typeof value !== 'string' || value === '') continue;
+
+      const oldValue = oldFlat[key];
+      if (typeof oldValue === 'string') {
+        // Replacing one human value with another is an update with history.
+        if (oldValue !== value) {
+          changes.push({ key, status: 'updated', value, old_value: oldValue });
+        }
+      } else {
+        // New key, or a null/empty placeholder being filled in: an addition.
+        changes.push({ key, status: 'added', value });
+      }
+    }
+
+    return changes;
+  } catch (error) {
+    if (verbose) {
+      console.log(chalk.dim(`  Skipping ${targetFile.path}: ${(error as Error).message}`));
+    }
+    return [];
+  }
+}
+
+/**
+ * Pair a target file back to its source file using the same matching the
+ * missing-translations flow uses in the source→target direction.
+ */
+function sourcePathFor(
+  targetFile: TranslationFile,
+  locale: string,
+  sourceFiles: TranslationFile[],
+  targetFiles: TranslationFile[],
+  config: ProjectConfig
+): string | null {
+  if (targetFile.multiLanguage) {
+    return targetFile.path;
+  }
+
+  const sourceLocale = config.sourceLocale;
+  const match = sourceFiles.find((sourceFile) => {
+    const paired = findTargetFile(targetFiles, locale, sourceFile, sourceLocale);
+    return paired?.path === targetFile.path;
+  });
+
+  return match?.path ?? null;
+}

--- a/src/utils/translation-processor.ts
+++ b/src/utils/translation-processor.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import { ProjectConfig } from '../types/index.js';
+import type { SkippedLanguage } from '../types/index.js';
 import { Spinner } from './spinner.js';
 
 /**
@@ -11,6 +12,7 @@ export interface TranslationStats {
   resultsBaseUrl: string | null;
   jobGroupShortUrl: string | null;
   failedLanguages: Set<string>;
+  skippedLanguages: Set<string>;
 }
 
 export interface TranslationJob {
@@ -26,6 +28,7 @@ export interface TranslationJobResponse {
     id: string;
     short_url: string;
   };
+  skipped_languages?: SkippedLanguage[];
 }
 
 export interface JobSourceInfo {
@@ -87,6 +90,7 @@ export interface TranslationResult {
   allJobIds: string[];
   resultsBaseUrl: string | null;
   jobGroupShortUrl: string | null;
+  skippedLanguages: string[];
   uniqueKeysTranslated: Set<string>;
   failedLanguages: string[];
 }
@@ -290,6 +294,24 @@ async function applyTranslations(
     return false;
   }
 
+  // Skip-auto-translation jobs are authoritative on the job, not its content:
+  // the API may echo the locale's existing translations as content, so we must
+  // not infer "translated" from a populated payload. Nothing to write, and the
+  // locale counts as skipped rather than translated.
+  if (data.auto_translate_disabled) {
+    stats.skippedLanguages.add(languageCode);
+    return false;
+  }
+
+  // Fallback for older backends without the explicit flag: a skipped job
+  // completes with all-nil content. Nothing to write either way.
+  const hasContent = Object.values(data.translations.data).some(
+    (value) => value !== null && value !== undefined
+  );
+  if (!hasContent) {
+    return false;
+  }
+
   const localeSourceKey = findMissingEntryKey(missingByLocale, languageCode, sourceInfo.sourceFilePath);
 
   if (!localeSourceKey || processedEntries.has(localeSourceKey)) {
@@ -381,6 +403,10 @@ async function processBatch(
   // Capture job group short URL if present in the response
   if (response.job_group?.short_url && !stats.jobGroupShortUrl) {
     stats.jobGroupShortUrl = response.job_group.short_url;
+  }
+
+  for (const skipped of response.skipped_languages ?? []) {
+    stats.skippedLanguages.add(skipped.code);
   }
 
   const jobSourceMapping = createJobSourceMapping(jobs, sourceFilePath);
@@ -481,7 +507,8 @@ export async function processTranslationBatches(
     languages: new Set<string>(),
     resultsBaseUrl: null,
     jobGroupShortUrl: null,
-    failedLanguages: new Set<string>()
+    failedLanguages: new Set<string>(),
+    skippedLanguages: new Set<string>()
   };
   const processedEntries = new Set<string>();
   const allJobIds: string[] = [];
@@ -515,6 +542,7 @@ export async function processTranslationBatches(
     allJobIds,
     resultsBaseUrl: stats.resultsBaseUrl,
     jobGroupShortUrl: stats.jobGroupShortUrl,
+    skippedLanguages: Array.from(stats.skippedLanguages),
     uniqueKeysTranslated,
     failedLanguages: Array.from(stats.failedLanguages)
   };

--- a/src/utils/translation-updater/index.ts
+++ b/src/utils/translation-updater/index.ts
@@ -80,8 +80,11 @@ async function _updateTranslationFile(
   }
 
   if (fileExt === 'po' || fileExt === 'pot') {
-    // Preserve old_values metadata for key versioning
-    const poResult = await updatePoFile(filePath, translations, languageCode, sourceFilePath, sourceLanguage);
+    // Array form carries old_values metadata for key versioning, pass it through.
+    // Record form has no metadata, so use the null-stripped map (as JSON/YAML do)
+    // to avoid writing awaiting keys as the literal string "null" into msgstr.
+    const poTranslations = Array.isArray(translations) ? translations : filteredTranslations;
+    const poResult = await updatePoFile(filePath, poTranslations, languageCode, sourceFilePath, sourceLanguage);
 
     if (config && isDjangoWorkflow(config) && Object.keys(filteredTranslations).length > 0) {
       await updateDjangoSourcesFile(filePath, filteredTranslations, languageCode, sourceFilePath, sourceLanguage);

--- a/tests/api/translations.test.js
+++ b/tests/api/translations.test.js
@@ -93,6 +93,24 @@ describe('translations API', () => {
       });
     });
 
+    it('passes skipped_languages through to the caller', async () => {
+      mockGetCurrentBranch.mockResolvedValueOnce('feature/skip');
+      mockApiRequest.mockResolvedValueOnce({
+        jobs: [{ id: 'job_123', status: 'completed' }],
+        skipped_languages: [{ code: 'ja_easy', reason: 'auto_translate_disabled' }]
+      });
+
+      const result = await createTranslationJob({
+        projectId: 'proj_123',
+        sourceFiles: [{ path: 'locales/en.yml', content: 'x', format: 'yaml' }],
+        targetLocales: ['ja_easy']
+      });
+
+      expect(result.skipped_languages).toEqual([
+        { code: 'ja_easy', reason: 'auto_translate_disabled' }
+      ]);
+    });
+
     it('returns an empty jobs no-op instead of throwing (#432)', async () => {
       // The backend returns { jobs: [] } when no key is eligible for translation
       // (e.g. only a `.one` form for an other-only locale). That is a benign

--- a/tests/utils/target-changes.test.ts
+++ b/tests/utils/target-changes.test.ts
@@ -1,0 +1,154 @@
+import { jest } from '@jest/globals';
+
+const mockExecSync = jest.fn();
+const mockReadFileSync = jest.fn();
+
+jest.unstable_mockModule('child_process', () => ({
+  execSync: mockExecSync
+}));
+
+import * as actualFs from 'fs';
+
+jest.unstable_mockModule('fs', () => ({
+  ...actualFs,
+  readFileSync: mockReadFileSync
+}));
+
+let detectTargetChanges: any;
+
+beforeAll(async () => {
+  const module = await import('../../src/utils/target-changes.js');
+  detectTargetChanges = module.detectTargetChanges;
+});
+
+const config = {
+  projectId: 'test-project',
+  sourceLocale: 'en',
+  outputLocales: ['ja_easy'],
+  translationFiles: { paths: ['config/locales/'] }
+} as any;
+
+const sourceFiles = [
+  { path: 'config/locales/en.yml', format: 'yml', locale: 'en' }
+];
+
+const targetFilesByLocale = {
+  ja_easy: [{ path: 'config/locales/ja_easy.yml', format: 'yml', locale: 'ja_easy' }]
+};
+
+function setupGitMock({ oldContent }: { oldContent: string | null }) {
+  mockExecSync.mockImplementation((cmd: any) => {
+    if (cmd === 'git rev-parse --git-dir') return '';
+    if (String(cmd).includes('git rev-parse --verify')) return '';
+    if (String(cmd).includes('git merge-base')) return 'abc123\n';
+    if (String(cmd).includes('git show')) {
+      if (oldContent === null) throw new Error('does not exist');
+      return oldContent;
+    }
+    throw new Error(`Unexpected git command: ${cmd}`);
+  });
+}
+
+beforeEach(() => {
+  mockExecSync.mockReset();
+  mockReadFileSync.mockReset();
+});
+
+describe('detectTargetChanges', () => {
+  test('detects updated and added values with old values attached', () => {
+    setupGitMock({
+      oldContent: 'ja_easy:\n  greeting: "こんにちは"\n  farewell: "さようなら"\n'
+    });
+    mockReadFileSync.mockReturnValue(
+      'ja_easy:\n  greeting: "やあ"\n  farewell: "さようなら"\n  hint: "ヒント"\n'
+    );
+
+    const result = detectTargetChanges(sourceFiles, targetFilesByLocale, config, false);
+
+    expect(result).toEqual([
+      {
+        path: 'config/locales/ja_easy.yml',
+        source_path: 'config/locales/en.yml',
+        locale: 'ja_easy',
+        format: 'yml',
+        changes: [
+          { key: 'greeting', status: 'updated', value: 'やあ', old_value: 'こんにちは' },
+          { key: 'hint', status: 'added', value: 'ヒント' }
+        ]
+      }
+    ]);
+  });
+
+  test('returns empty array when nothing changed', () => {
+    const content = 'ja_easy:\n  greeting: "こんにちは"\n';
+    setupGitMock({ oldContent: content });
+    mockReadFileSync.mockReturnValue(content);
+
+    expect(detectTargetChanges(sourceFiles, targetFilesByLocale, config, false)).toEqual([]);
+  });
+
+  test('treats a file missing at the base ref as all-added', () => {
+    setupGitMock({ oldContent: null });
+    mockReadFileSync.mockReturnValue('ja_easy:\n  greeting: "やあ"\n');
+
+    const result = detectTargetChanges(sourceFiles, targetFilesByLocale, config, false);
+
+    expect(result![0].changes).toEqual([
+      { key: 'greeting', status: 'added', value: 'やあ' }
+    ]);
+  });
+
+  test('skips empty and non-string values', () => {
+    setupGitMock({ oldContent: 'ja_easy:\n  count: 1\n' });
+    mockReadFileSync.mockReturnValue('ja_easy:\n  count: 2\n  blank: ""\n');
+
+    expect(detectTargetChanges(sourceFiles, targetFilesByLocale, config, false)).toEqual([]);
+  });
+
+  test('treats a null placeholder replaced by a string as added', () => {
+    // Untranslated YAML keys are commonly null placeholders; a reviewer filling
+    // one in must be detected, not silently dropped.
+    setupGitMock({ oldContent: 'ja_easy:\n  greeting:\n  farewell: "さようなら"\n' });
+    mockReadFileSync.mockReturnValue('ja_easy:\n  greeting: "こんにちは"\n  farewell: "さようなら"\n');
+
+    const result = detectTargetChanges(sourceFiles, targetFilesByLocale, config, false);
+
+    expect(result![0].changes).toEqual([
+      { key: 'greeting', status: 'added', value: 'こんにちは' }
+    ]);
+  });
+
+  test('multi-language files use their own path as source_path', () => {
+    setupGitMock({
+      oldContent: 'en:\n  greeting: "Hello"\nsv:\n  greeting: "Hej"\n'
+    });
+    mockReadFileSync.mockReturnValue('en:\n  greeting: "Hello"\nsv:\n  greeting: "Tjena"\n');
+
+    const result = detectTargetChanges(
+      [{ path: 'config/locales/shared.yml', format: 'yml', locale: 'en', multiLanguage: true }] as any,
+      { sv: [{ path: 'config/locales/shared.yml', format: 'yml', locale: 'sv', multiLanguage: true }] } as any,
+      { ...config, outputLocales: ['sv'] },
+      false
+    );
+
+    expect(result).toEqual([
+      {
+        path: 'config/locales/shared.yml',
+        source_path: 'config/locales/shared.yml',
+        locale: 'sv',
+        format: 'yml',
+        changes: [
+          { key: 'greeting', status: 'updated', value: 'Tjena', old_value: 'Hej' }
+        ]
+      }
+    ]);
+  });
+
+  test('returns null when git is unavailable', () => {
+    mockExecSync.mockImplementation(() => {
+      throw new Error('git: command not found');
+    });
+
+    expect(detectTargetChanges(sourceFiles, targetFilesByLocale, config, false)).toBeNull();
+  });
+});

--- a/tests/utils/translation-processor.test.js
+++ b/tests/utils/translation-processor.test.js
@@ -108,6 +108,58 @@ describe('translation-processor', () => {
       expect(result.uniqueKeysTranslated.has('welcome')).toBe(true);
     });
 
+    it('treats an auto_translate_disabled job as skipped even when it carries existing content', async () => {
+      const batches = [
+        {
+          sourceFilePath: 'locales/en.json',
+          sourceFile: {
+            path: 'locales/en.json',
+            format: 'json',
+            content: Buffer.from(JSON.stringify({ welcome: 'Welcome' })).toString('base64')
+          },
+          localeEntries: ['ja_easy:locales/en.json'],
+          locales: ['ja_easy']
+        }
+      ];
+
+      const missingByLocale = {
+        'ja_easy:locales/en.json': {
+          locale: 'ja_easy',
+          path: 'locales/en.json',
+          targetPath: 'locales/ja_easy.json',
+          keys: { welcome: { value: 'Welcome', sourceKey: 'welcome' } },
+          keyCount: 1
+        }
+      };
+
+      mockTranslationUtils.createTranslationJob.mockResolvedValue({
+        jobs: [{ id: 'job-skip', language: { code: 'ja_easy' } }]
+      });
+
+      // The skipped job echoes the locale's EXISTING translation as content.
+      // The client must rely on the explicit skip signal, not on content shape.
+      mockTranslationUtils.checkJobStatus.mockResolvedValue({
+        status: 'completed',
+        auto_translate_disabled: true,
+        translations: { data: { welcome: 'ようこそ' } },
+        language: { code: 'ja_easy' }
+      });
+
+      const result = await processTranslationBatches(
+        batches,
+        missingByLocale,
+        { projectId: 'test-project' },
+        false,
+        { console: mockConsole, translationUtils: mockTranslationUtils }
+      );
+
+      expect(mockTranslationUtils.updateTranslationFile).not.toHaveBeenCalled();
+      expect(result.totalLanguages).toBe(0);
+      expect(result.languages).not.toContain('ja_easy');
+      expect(result.skippedLanguages).toContain('ja_easy');
+      expect(result.uniqueKeysTranslated.size).toBe(0);
+    });
+
     it('passes source metadata through when writing PO translations', async () => {
       const batches = [{
         sourceFilePath: 'locales/en/messages.po',

--- a/tests/utils/translation-updater.test.js
+++ b/tests/utils/translation-updater.test.js
@@ -1351,6 +1351,36 @@ en:
       expect(content).toContain('Auf Wiedersehen');
     });
 
+    it('does not write null target values as the literal string "null" in .po files', async () => {
+      const sourceFilePath = path.join(tempDir, 'source.po');
+      const sourceContent = [
+        'msgid ""',
+        'msgstr ""',
+        '"Content-Type: text/plain; charset=UTF-8\\n"',
+        '',
+        'msgid "hello"',
+        'msgstr "Hello"',
+        '',
+        'msgid "goodbye"',
+        'msgstr "Goodbye"',
+        ''
+      ].join('\n');
+      fs.writeFileSync(sourceFilePath, sourceContent);
+
+      const targetFilePath = path.join(tempDir, 'target.po');
+      // Mixed payload: one translated key, one still awaiting (null).
+      const translations = {
+        hello: 'Hej',
+        goodbye: null
+      };
+
+      await updateTranslationFile(targetFilePath, translations, 'sv', sourceFilePath);
+
+      const targetContent = fs.readFileSync(targetFilePath, 'utf8');
+      expect(targetContent).toContain('msgstr "Hej"');
+      expect(targetContent).not.toContain('msgstr "null"');
+    });
+
     it('deletes keys from YAML files with duplicate keys without crashing', async () => {
       const filePath = path.join(tempDir, 'sv.yml');
       const yamlWithDuplicates = [


### PR DESCRIPTION
Ingest customer-authored target translation changes into the existing PR review flow instead of auto-translating them.

- Detect added/updated target values via git diff (--changedOnly) and POST them to the PR-scoped ingestion endpoint for review.
- Surface skipped (auto-translation-disabled) languages and exclude them from the summary count, keying off the backend's authoritative auto_translate_disabled signal rather than payload content shape.
- Handle target values that replace a null placeholder as additions.