### PR TITLE
Harden BYO change detection against git failures and cap miscounts

### DIFF
--- a/src/utils/git-changes.ts
+++ b/src/utils/git-changes.ts
@@ -346,13 +346,16 @@ export function diffFileKeys(
     const oldTranslations = isPo ? oldObj : extractLocaleContent(oldObj, file.locale);
     oldFlat = isPo ? extractPoKeys(oldObj) : flattenTranslations(oldTranslations);
   } catch (error) {
+    const err = error as Error;
+    const missingAtRef = err.message.includes('exists on disk, but not in') || err.message.includes('does not exist');
+    if (!missingAtRef) {
+      // A git failure or an unparsable base file is NOT an empty base — falling through
+      // would report every key as added, and the backend trusts those. Callers catch
+      // per-file and skip.
+      throw error;
+    }
     if (verbose) {
-      const err = error as Error;
-      if (err.message.includes('exists on disk, but not in') || err.message.includes('does not exist')) {
-        console.log(chalk.dim(`  ${file.path}: new file (all keys changed)`));
-      } else {
-        console.log(chalk.yellow(`  ${file.path}: Parse error - ${err.message}`));
-      }
+      console.log(chalk.dim(`  ${file.path}: new file (all keys changed)`));
     }
   }
 

--- a/src/utils/target-changes.ts
+++ b/src/utils/target-changes.ts
@@ -63,20 +63,18 @@ export function detectTargetChanges(
       const changes = detectFileChanges(targetFile, resolvedRef, verbose);
       if (changes.length === 0) continue;
 
-      totalChanges += changes.length;
-      if (totalChanges > MAX_TOTAL_CHANGES) {
-        if (verbose) {
-          console.log(chalk.yellow(`Skipping translation ingestion: more than ${MAX_TOTAL_CHANGES} changed values`));
-        }
-        return null;
-      }
-
       const sourcePath = sourcePathFor(targetFile, locale, sourceFiles, targetFiles, config);
       if (!sourcePath) {
         if (verbose) {
           console.log(chalk.dim(`  ${targetFile.path}: no matching source file, skipping ingestion`));
         }
         continue;
+      }
+
+      totalChanges += changes.length;
+      if (totalChanges > MAX_TOTAL_CHANGES) {
+        console.log(chalk.yellow(`Skipping translation ingestion: more than ${MAX_TOTAL_CHANGES} changed values`));
+        return null;
       }
 
       result.push({
@@ -103,9 +101,7 @@ export function detectTargetChanges(
 
     totalChanges += updatedChanges.length;
     if (totalChanges > MAX_TOTAL_CHANGES) {
-      if (verbose) {
-        console.log(chalk.yellow(`Skipping translation ingestion: more than ${MAX_TOTAL_CHANGES} changed values`));
-      }
+      console.log(chalk.yellow(`Skipping translation ingestion: more than ${MAX_TOTAL_CHANGES} changed values`));
       return null;
     }
 
@@ -152,9 +148,7 @@ function detectFileChanges(
 
     return changes;
   } catch (error) {
-    if (verbose) {
-      console.log(chalk.dim(`  Skipping ${targetFile.path}: ${(error as Error).message}`));
-    }
+    console.log(chalk.yellow(`  Skipping ${targetFile.path} from translation ingestion: ${(error as Error).message}`));
     return [];
   }
 }

--- a/tests/utils/target-changes.test.ts
+++ b/tests/utils/target-changes.test.ts
@@ -173,6 +173,70 @@ describe('detectTargetChanges', () => {
   });
 });
 
+describe('detectTargetChanges — ingestion hardening', () => {
+  const manyKeys = (prefix: string, n: number) =>
+    Array.from({ length: n }, (_, i) => `  k${i}: "${prefix}${i}"`).join('\n');
+
+  test('git failures other than a missing base file do not fabricate additions', () => {
+    mockExecSync.mockImplementation((cmd: any) => {
+      if (cmd === 'git rev-parse --git-dir') return '';
+      if (String(cmd).includes('git rev-parse --verify')) return '';
+      if (String(cmd).includes('git merge-base')) return 'abc123\n';
+      if (String(cmd).includes('git show')) {
+        if (String(cmd).includes('ja_easy.yml')) throw new Error('fatal: unable to read tree abc123');
+        return 'en:\n  greeting: "Hello"\n';
+      }
+      throw new Error(`Unexpected git command: ${cmd}`);
+    });
+    setupReadMock({
+      'en.yml': 'en:\n  greeting: "Hello"\n',
+      'ja_easy.yml': 'ja_easy:\n  greeting: "こんにちは"\n'
+    });
+
+    // The unchanged ja_easy greeting must not be reported as added just because
+    // git failed — the backend would trust it and create/stage from it.
+    expect(detectTargetChanges(sourceFiles, targetFilesByLocale, config, false)).toEqual([]);
+  });
+
+  test('an unpaired target file does not consume the ingestion cap', () => {
+    const pairedAndUnpaired = {
+      ja_easy: [
+        { path: 'config/locales/extra/notes.yml', format: 'yml', locale: 'ja_easy' },
+        { path: 'config/locales/ja_easy.yml', format: 'yml', locale: 'ja_easy' }
+      ]
+    } as any;
+    setupGitMock({ oldContent: { 'en.yml': 'en:\n  title: "App"\n' } });
+    setupReadMock({
+      'en.yml': 'en:\n  title: "App"\n',
+      'extra/notes.yml': `ja_easy:\n${manyKeys('n', 600)}\n`,
+      'ja_easy.yml': `ja_easy:\n${manyKeys('j', 600)}\n`
+    });
+
+    const result = detectTargetChanges(sourceFiles, pairedAndUnpaired, config, false);
+
+    // 600 changes in the unpaired notes.yml must not push the paired file over the cap.
+    const paired = result?.find(r => r.path === 'config/locales/ja_easy.yml');
+    expect(paired?.changes).toHaveLength(600);
+  });
+
+  test('cap suppression is reported without verbose', () => {
+    const spy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      setupGitMock({ oldContent: { 'en.yml': 'en:\n  title: "App"\n' } });
+      setupReadMock({
+        'en.yml': 'en:\n  title: "App"\n',
+        'ja_easy.yml': `ja_easy:\n${manyKeys('j', 1100)}\n`
+      });
+
+      expect(detectTargetChanges(sourceFiles, targetFilesByLocale, config, false)).toBeNull();
+      const logged = spy.mock.calls.map(args => String(args[0])).join('\n');
+      expect(logged).toContain('more than 1000 changed values');
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
 describe('detectTargetChanges — source_value attachment', () => {
   test('attaches source_value to target changes whose key exists in the source file', () => {
     setupGitMock({


### PR DESCRIPTION
Codex review follow-up on #46:

- diffFileKeys no longer treats every git-show/parse failure as an empty base file — only genuinely-missing-at-ref falls through to all-added. Other failures throw and the callers skip that file, so a git hiccup can't fabricate added changes the backend would trust (and now hydrate keys from).
- Target files that fail source pairing no longer consume the ingestion cap, so an unpaired file can't suppress unrelated changes.
- Cap suppression and per-file ingestion skips are logged without --verbose.