### PR TITLE
Ensure fallback path is visible

### DIFF
--- a/src/commands/translate.ts
+++ b/src/commands/translate.ts
@@ -143,7 +143,6 @@ async function fetchLocalePluralCategories(
   projectId: string,
   outputLocales: string[],
   settingsUtils: { fetchSettings: (projectId: string) => Promise<any> },
-  verbose: boolean | undefined,
   logger: { log: (message?: any, ...optionalParams: any[]) => void }
 ): Promise<Record<string, string[]>> {
   const CLDR_CATEGORIES = ['zero', 'one', 'two', 'few', 'many', 'other'];
@@ -170,9 +169,10 @@ async function fetchLocalePluralCategories(
       }
     }
   } catch {
-    if (verbose) {
-      logger.log(chalk.gray('ℹ Could not fetch locale plural categories; using exact key matching.'));
-    }
+    // Without categories, missing-detection falls back to exact key matching, which
+    // re-flags flat-target plurals as missing on every run and re-charges credits
+    // (#432). Always warn, not just under --verbose.
+    logger.log(chalk.yellow('\n⚠ Could not fetch locale plural categories. Falling back to exact key matching, which can re-translate plural keys that are already translated and use credits. Re-run once the connection is restored if you see unexpected plural updates.\n'));
   }
   return map;
 }
@@ -208,7 +208,6 @@ export async function translate(options: TranslationOptions = {}, deps: Translat
     config.projectId,
     config.outputLocales,
     settingsUtils,
-    verbose,
     console
   );
 

--- a/tests/commands/translate.test.js
+++ b/tests/commands/translate.test.js
@@ -277,6 +277,19 @@ describe('translate command', () => {
     expect(config.localePluralCategories).toEqual({});
   });
 
+  it('warns without --verbose when the category fetch fails (credit risk, #432)', async () => {
+    stubFilesForCategoryTest();
+    settingsUtils.fetchSettings.mockRejectedValue(new Error('network'));
+
+    await translate({}, createTranslateDeps());
+
+    const consoleOutput = mockConsole.log.mock.calls
+      .map(call => typeof call[0] === 'string' ? call[0] : JSON.stringify(call[0]))
+      .join('\n');
+    expect(consoleOutput).toContain('Could not fetch locale plural categories');
+    expect(consoleOutput).toContain('credits');
+  });
+
   it('keys the category map by the config locale spelling (zh_cn vs zh-CN)', async () => {
     stubFilesForCategoryTest();
     configUtils.getProjectConfig.mockResolvedValue({


### PR DESCRIPTION
Related to #432, already shipped weeks ago in 0.0.61. If the fallback path that can reintroduce the symptom ever triggers don't let it happen silently.