### PR TITLE
Report source files that fail to parse instead of silently skipping them

### DIFF
--- a/src/commands/translate.ts
+++ b/src/commands/translate.ts
@@ -237,7 +237,16 @@ export async function translate(options: TranslationOptions = {}, deps: Translat
   }
 
   const result = await fileUtils.findTranslationFiles(config, { verbose, returnFullResult: true });
-  const { sourceFiles, targetFilesByLocale, allFiles } = result as TranslationFilesResult;
+  const { sourceFiles, targetFilesByLocale, allFiles, parseFailures = [] } = result as TranslationFilesResult;
+
+  if (parseFailures.length > 0) {
+    console.error(chalk.red(`\n✖ ${parseFailures.length} translation file(s) failed to parse and were skipped:`));
+    for (const failure of parseFailures) {
+      console.error(chalk.red(`  - ${failure.path}: ${failure.error}`));
+    }
+    console.error(chalk.red('Every key in a skipped file is missing from this run. Fix the file and re-run.\n'));
+    process.exitCode = 1;
+  }
 
   if (!allFiles || allFiles.length === 0) {
     console.error(chalk.red('\n✖ No translation files found in the specified paths.\n'));
@@ -450,6 +459,10 @@ export async function translate(options: TranslationOptions = {}, deps: Translat
       console.error(chalk.red(`» ${translationResult.failedLanguages.length} language(s) failed: ${translationResult.failedLanguages.join(', ')}`));
       if (translationResult.uniqueKeysTranslated.size > 0) {
         console.log(`» Successfully updated ${translationResult.uniqueKeysTranslated.size} keys in ${translationResult.totalLanguages} languages`);
+      }
+    } else if (parseFailures.length > 0) {
+      if (translationResult.uniqueKeysTranslated.size > 0) {
+        console.log(`» Updated ${translationResult.uniqueKeysTranslated.size} keys in ${translationResult.totalLanguages} languages`);
       }
     } else {
       console.log(chalk.green('✓ Translations complete!'));

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -167,11 +167,17 @@ export interface Organization {
   projects: Project[];
 }
 
+export interface TranslationFileParseFailure {
+  path: string;
+  error: string;
+}
+
 // For translation file results
 export interface TranslationFilesResult {
   allFiles: TranslationFile[];
   sourceFiles: TranslationFile[];
   targetFilesByLocale: Record<string, TranslationFile[]>;
+  parseFailures: TranslationFileParseFailure[];
 }
 
 // Key identifier for manifest (used in finalize endpoint)

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -7,6 +7,7 @@ import { promises as fs } from 'fs';
 import type {
   TranslationConfig,
   TranslationFile,
+  TranslationFileParseFailure,
   TranslationFilesResult,
   TranslationFileOptions
 } from '../types/index.js';
@@ -351,6 +352,7 @@ export async function findTranslationFiles(
   } = translationFiles || {};
 
   const processedFiles: TranslationFile[] = [];
+  const parseFailures: TranslationFileParseFailure[] = [];
   let betaNoticeEmitted = false;
 
   // Adjustment to handle single-item braces, common mistake to use {json} instead of *.json, its not supported by glob
@@ -526,6 +528,8 @@ export async function findTranslationFiles(
           } else if (format === 'yml' || format === 'yaml') {
             console.warn(chalk.gray('  Tip: Check for proper indentation and quote matching in your YAML file.'));
           }
+
+          parseFailures.push({ path: file, error: error.message });
         } else if (error.message.includes('Could not extract locale from path')) {
           console.warn(chalk.yellow(`Warning: ${error.message}`), chalk.gray('[Skipping file]'));
         } else if (verbose) {
@@ -556,7 +560,8 @@ export async function findTranslationFiles(
   return {
     allFiles,
     sourceFiles,
-    targetFilesByLocale
+    targetFilesByLocale,
+    parseFailures
   };
 }
 

--- a/tests/commands/translate.test.js
+++ b/tests/commands/translate.test.js
@@ -98,6 +98,7 @@ describe('translate command', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+    process.exitCode = undefined;
   });
 
   it('successfully translates missing keys', async () => {
@@ -228,6 +229,34 @@ describe('translate command', () => {
 
     // Verify no errors were logged
     expect(mockConsole.error).not.toHaveBeenCalled();
+  });
+
+  it('exits non-zero and reports files that failed to parse, even when translation succeeds', async () => {
+    const sourceFilePath = 'locales/en/common.json';
+
+    fileUtils.findTranslationFiles.mockResolvedValue({
+      sourceFiles: [{
+        path: sourceFilePath,
+        format: 'json',
+        content: Buffer.from(JSON.stringify({ hello: 'Hello' })).toString('base64')
+      }],
+      targetFilesByLocale: { fr: [] },
+      allFiles: [{ path: sourceFilePath, locale: 'en' }],
+      parseFailures: [
+        { path: 'locales/en/broken.yml', error: 'Failed to parse yml file in locales/en/broken.yml: Map keys must be unique at line 12' }
+      ]
+    });
+
+    translationUtils.findMissingTranslationsByLocale.mockReturnValue({ missing: {}, removed: [] });
+
+    await translate({ verbose: false }, createTranslateDeps());
+
+    const errorOutput = mockConsole.error.mock.calls
+      .map(call => typeof call[0] === 'string' ? call[0] : JSON.stringify(call[0]))
+      .join('\n');
+
+    expect(errorOutput).toContain('locales/en/broken.yml');
+    expect(process.exitCode).toBe(1);
   });
 
   function stubFilesForCategoryTest() {

--- a/tests/utils/files.test.js
+++ b/tests/utils/files.test.js
@@ -376,6 +376,31 @@ en:
     expect(result[0].path).toBe('config/locales/en.json');
   });
 
+  it('reports parse failures in the full result instead of silently dropping them', async () => {
+    mockGlob.mockResolvedValue(['config/locales/en.json', 'config/locales/invalid.json']);
+    mockReadFile.mockImplementation((path) => {
+      if (path === 'config/locales/en.json') {
+        return Promise.resolve('{"hello": "Hello"}');
+      } else {
+        return Promise.resolve('{ invalid json }');
+      }
+    });
+
+    const config = {
+      translationFiles: {
+        paths: ['config/locales/'],
+        localeRegex: '([a-z]{2}(?:-[A-Z]{2})?)\\.(?:yml|yaml|json)$'
+      }
+    };
+
+    const result = await findTranslationFiles(config, { returnFullResult: true });
+
+    expect(result.allFiles).toHaveLength(1);
+    expect(result.parseFailures).toHaveLength(1);
+    expect(result.parseFailures[0].path).toBe('config/locales/invalid.json');
+    expect(result.parseFailures[0].error).toMatch(/Failed to parse/);
+  });
+
   it('finds files in nested directories', async () => {
     mockGlob.mockResolvedValue([
       'config/locales/en/common.json',


### PR DESCRIPTION
Fixes #510. findTranslationFiles() caught parse errors, printed a yellow warning, and continued, the failed file was simply absent from processedFiles with no record of the skip anywhere in the return value. 