### PR TITLE
Better Django and Phoenix init

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -7,8 +7,8 @@ import { configService } from '../utils/config.js';
 import { checkAuth } from '../utils/auth.js';
 import { login } from './login.js';
 import { importService, ImportResult } from '../utils/import-service.js';
-import { createGitHubActionFile, workflowExists } from '../utils/github.js';
-import { directoryExists, findFirstExistingPath, getDirectoryContents, isValidLocale, DirectoryContents } from '../utils/files.js';
+import { createGitHubActionFile, workflowExists, PHOENIX_ELIXIR_VERSION, PHOENIX_OTP_VERSION, DJANGO_PYTHON_VERSION } from '../utils/github.js';
+import { directoryExists, findFirstExistingPath, findFirstGettextCatalogPath, getDirectoryContents, isValidLocale, DirectoryContents } from '../utils/files.js';
 import { ProjectConfig as BaseProjectConfig, CustomLocale } from '../types/index.js';
 import { verifyApiKey } from '../api/auth.js';
 import { Spinner } from '../utils/spinner.js';
@@ -71,6 +71,7 @@ interface ProjectTypeConfig {
     commonPaths?: string[];
     ignorePaths?: string[];
     workflow?: string;
+    extractor?: string;
     // Literal glob patterns for the GitHub Actions paths: filter.
     // Do not use brace expansion ({ts,tsx}); list one entry per extension.
     sourceCodePaths?: string[];
@@ -92,6 +93,7 @@ interface ProjectDetectionResult {
     commonPaths?: string[];
     ignorePaths?: string[];
     workflow?: string;
+    extractor?: string;
     // Literal glob patterns for the GitHub Actions paths: filter.
     // Do not use brace expansion ({ts,tsx}); list one entry per extension.
     sourceCodePaths?: string[];
@@ -165,12 +167,14 @@ const PROJECT_TYPES: ProjectTypes = {
       translationPath: 'translations/',
       filePattern: '**/*.po',
       ignorePaths: ['**/sources/**'],
-      workflow: 'django'
+      workflow: 'django',
+      extractor: 'django',
+      sourceCodePaths: ['**/*.py', '**/*.html', '**/*.txt']
     },
     commonPaths: [
-      'translations',
       'locale',
-      'locales'
+      'locales',
+      'translations'
     ]
   },
   rails: {
@@ -187,10 +191,18 @@ const PROJECT_TYPES: ProjectTypes = {
     directIndicators: ['mix.exs'],
     defaults: {
       translationPath: 'priv/gettext/',
-      filePattern: '**/*.po'
+      filePattern: '**/*.po',
+      extractor: 'phoenix',
+      // Umbrella projects keep code in apps/<app>/lib, so both shapes are watched.
+      sourceCodePaths: [
+        'lib/**/*.ex', 'lib/**/*.exs', 'lib/**/*.eex', 'lib/**/*.heex', 'lib/**/*.leex',
+        'apps/*/lib/**/*.ex', 'apps/*/lib/**/*.exs', 'apps/*/lib/**/*.eex',
+        'apps/*/lib/**/*.heex', 'apps/*/lib/**/*.leex'
+      ]
     },
     commonPaths: [
-      'priv/gettext'
+      'priv/gettext',
+      'apps/*/priv/gettext'
     ]
   },
   nextIntl: {
@@ -422,7 +434,13 @@ async function detectProjectType(): Promise<ProjectDetectionResult> {
     if (!isFramework) continue;
 
     if (config.commonPaths) {
-      const translationPath = await findFirstExistingPath(config.commonPaths);
+      // For gettext projects the catalog check is authoritative: falling back to a
+      // name-only match would re-propose the directories it just rejected (a Django
+      // app named locales/, a Python package named translations/). When it finds
+      // nothing, the framework default is the better answer than a wrong directory.
+      const translationPath = config.defaults.extractor
+        ? await findFirstGettextCatalogPath(config.commonPaths)
+        : await findFirstExistingPath(config.commonPaths);
       if (translationPath) {
         return {
           type,
@@ -555,15 +573,34 @@ async function handleImportProcess(
   }
 }
 
-async function handleGitHubWorkflowSetup(
-  basePath: string,
-  translationPaths: string[],
-  promptService: IPromptService,
-  console: Console,
-  githubUtils: { createGitHubActionFile: typeof createGitHubActionFile; workflowExists: typeof workflowExists },
-  autoAnswer?: boolean,
-  sourceCodePaths?: string[]
-): Promise<WorkflowSetupResult> {
+interface WorkflowSetupParams {
+  basePath: string;
+  translationPaths: string[];
+  promptService: IPromptService;
+  console: Console;
+  githubUtils: { createGitHubActionFile: typeof createGitHubActionFile; workflowExists: typeof workflowExists };
+  autoAnswer?: boolean;
+  sourceCodePaths?: string[];
+  extractor?: string;
+  locales?: string[];
+  extractWorkingDirectory?: string;
+  pythonInstall?: string;
+}
+
+async function handleGitHubWorkflowSetup(params: WorkflowSetupParams): Promise<WorkflowSetupResult> {
+  const {
+    basePath,
+    translationPaths,
+    promptService,
+    console,
+    githubUtils,
+    autoAnswer,
+    sourceCodePaths,
+    extractor,
+    locales,
+    extractWorkingDirectory,
+    pythonInstall
+  } = params;
   if (githubUtils.workflowExists(basePath)) {
     console.log(chalk.green('✓ GitHub Actions workflow found'));
     console.log(chalk.yellow('\n⚠️  Remember to add your API key to repository secrets:'));
@@ -588,7 +625,12 @@ async function handleGitHubWorkflowSetup(
   }
 
   try {
-    const workflowFile = await githubUtils.createGitHubActionFile(basePath, translationPaths, sourceCodePaths);
+    const workflowFile = await githubUtils.createGitHubActionFile(
+      basePath,
+      translationPaths,
+      sourceCodePaths,
+      { extractor, locales, extractWorkingDirectory, pythonInstall }
+    );
     console.log(chalk.green(`\n✓ Created GitHub Action workflow at ${workflowFile}`));
     console.log('\nNext steps:');
     console.log('1. Add your API key to your repository\'s secrets:');
@@ -616,6 +658,33 @@ function printLinguiWorkflowNotice(console: Console): void {
   console.log('\nWithout this, the workflow will not pick up new translatable strings.\n');
 }
 
+function printExtractorNotice(extractor: string | undefined, console: Console, pythonInstall?: string): void {
+  if (extractor === 'django') {
+    printDjangoWorkflowNotice(console, pythonInstall);
+  } else if (extractor === 'phoenix') {
+    printPhoenixWorkflowNotice(console);
+  }
+}
+
+function printPhoenixWorkflowNotice(console: Console): void {
+  console.log(chalk.yellow('\n⚠️  Check the extract step in the generated workflow'));
+  console.log('\nThe workflow runs `mix gettext.extract --merge` to pick up new messages');
+  console.log(`before translating, on Elixir ${PHOENIX_ELIXIR_VERSION} / OTP ${PHOENIX_OTP_VERSION}.`);
+  console.log('Adjust the versions to match your project.\n');
+}
+
+function printDjangoWorkflowNotice(console: Console, pythonInstall?: string): void {
+  const install = pythonInstall || 'pip install -r requirements.txt';
+  console.log(chalk.yellow('\n⚠️  Check the extract step in the generated workflow'));
+  console.log('\nThe workflow runs `makemessages` to pick up new strings before translating.');
+  console.log(`It installs dependencies with \`${install}\` on Python ${DJANGO_PYTHON_VERSION},`);
+  console.log('so adjust that if your project does it differently.');
+  console.log('\nIf you wrap extraction in your own command or make target, point the step');
+  console.log('at that instead. Extra flags like --ignore or --add-location belong there too.');
+  console.log('\nTranslated .po files still need `compilemessages` to take effect,');
+  console.log('usually already part of your build or deploy rather than CI.\n');
+}
+
 function displayFinalInstructions(
   workflowCreated: boolean,
   workflowExists: boolean,
@@ -638,6 +707,78 @@ function displayFinalInstructions(
     console.log('\nYou can run translations manually with:');
   }
   console.log('  npx @localheroai/cli translate');
+}
+
+// Lockfile decides how CI installs dependencies. requirements.txt is the fallback
+// because it is the only one that works without an extra tool.
+const PYTHON_INSTALLERS: Array<{ lockfile: string; install: string }> = [
+  { lockfile: 'uv.lock', install: 'uv sync --frozen' },
+  { lockfile: 'poetry.lock', install: 'poetry install --no-interaction' },
+  { lockfile: 'Pipfile.lock', install: 'pipenv install --deploy' }
+];
+
+async function detectPythonInstall(): Promise<string | undefined> {
+  for (const { lockfile, install } of PYTHON_INSTALLERS) {
+    try {
+      const stats = await fs.stat(lockfile);
+      if (stats.isFile()) return install;
+    } catch {
+      continue;
+    }
+  }
+  return undefined;
+}
+
+const UMBRELLA_APP_PATTERN = /^(apps\/[^/]+)\//;
+
+// `mix gettext.extract` must run inside the child app: from the umbrella root gettext
+// warns about conflicting backends and writes only one app's catalogs.
+function umbrellaAppDirectory(translationPaths: string[]): string | undefined {
+  for (const candidate of translationPaths) {
+    // Detection can yield native separators, so normalize before matching.
+    const match = UMBRELLA_APP_PATTERN.exec(candidate.split('\\').join('/'));
+    if (match) {
+      return match[1];
+    }
+  }
+  return undefined;
+}
+
+type ProjectDefaults = ProjectDetectionResult['defaults'];
+
+const GETTEXT_PATH_PATTERN = /(^|\/)priv\/gettext(\/|$)/;
+
+// Detection is filesystem-relative and can miss when init runs from a subdirectory
+// or the project root marker is not where it is expected. The saved config is then
+// the better evidence: an explicit django workflow, or a Phoenix-shaped catalog path.
+async function rootMarkerExists(marker: string): Promise<boolean> {
+  try {
+    return (await fs.stat(marker)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+// The generated extract step runs from the repository root, so an extractor is only
+// safe to infer when the project's root marker is actually there. Without this a
+// project whose manage.py sits in a subdirectory would get `python manage.py`
+// commands that cannot run, replacing a workflow that used to succeed.
+async function resolveWorkflowDefaults(
+  detected: ProjectDefaults | undefined,
+  existingConfig: BaseProjectConfig
+): Promise<ProjectDefaults | undefined> {
+  if (!detected || detected.extractor) {
+    return detected;
+  }
+  if (existingConfig.translationFiles?.workflow === 'django' && await rootMarkerExists('manage.py')) {
+    return PROJECT_TYPES.django.defaults;
+  }
+  const paths = existingConfig.translationFiles?.paths || [];
+  const looksLikePhoenix = paths.some(p => GETTEXT_PATH_PATTERN.test(p.split('\\').join('/')));
+  if (looksLikePhoenix && await rootMarkerExists('mix.exs')) {
+    return PROJECT_TYPES.phoenix.defaults;
+  }
+  return detected;
 }
 
 async function handleExistingConfiguration(
@@ -704,15 +845,38 @@ async function handleExistingConfiguration(
     }
   }
 
-  const workflowResult = await handleGitHubWorkflowSetup(
+  // The extractor is derived from the project type rather than persisted, so it has
+  // to be re-detected. Detection is filesystem-relative and can miss (init run from a
+  // subdirectory, manage.py not at the root), so a persisted django workflow is
+  // trusted as evidence when it does.
+  const detectedDefaults = githubUtils.workflowExists(basePath)
+    ? undefined
+    : (await detectProjectType()).defaults;
+  const workflowDefaults = await resolveWorkflowDefaults(detectedDefaults, existingConfig);
+
+  const existingPythonInstall = workflowDefaults?.extractor === 'django'
+    ? await detectPythonInstall()
+    : undefined;
+  const workflowResult = await handleGitHubWorkflowSetup({
     basePath,
-    existingConfig.translationFiles?.paths || [''],
+    translationPaths: existingConfig.translationFiles?.paths || [''],
     promptService,
     console,
     githubUtils,
-    nonInteractive ? options.githubAction === true : undefined
-  );
+    autoAnswer: nonInteractive ? options.githubAction === true : undefined,
+    sourceCodePaths: workflowDefaults?.sourceCodePaths,
+    extractor: workflowDefaults?.extractor,
+    locales: existingConfig.outputLocales,
+    extractWorkingDirectory: workflowDefaults?.extractor === 'phoenix'
+      ? umbrellaAppDirectory(existingConfig.translationFiles?.paths || [])
+      : undefined,
+    pythonInstall: existingPythonInstall
+  });
   workflowCreated = workflowResult.created;
+
+  if (workflowCreated) {
+    printExtractorNotice(workflowDefaults?.extractor, console, existingPythonInstall);
+  }
 
   displayFinalInstructions(workflowCreated, githubUtils.workflowExists(basePath), false, console);
 }
@@ -750,19 +914,32 @@ async function handleNewProjectSetup(
     console.log(chalk.green(`✓ Project created, view it at: ${url}\n`));
   }
 
-  const workflowResult = await handleGitHubWorkflowSetup(
+  const pythonInstall = projectDefaults.defaults.extractor === 'django'
+    ? await detectPythonInstall()
+    : undefined;
+  const workflowResult = await handleGitHubWorkflowSetup({
     basePath,
-    config.translationFiles.paths.length > 0 ? config.translationFiles.paths : [''],
+    translationPaths: config.translationFiles.paths.length > 0 ? config.translationFiles.paths : [''],
     promptService,
     console,
     githubUtils,
-    nonInteractive ? options.githubAction === true : undefined,
-    projectDefaults.defaults.sourceCodePaths
-  );
+    autoAnswer: nonInteractive ? options.githubAction === true : undefined,
+    sourceCodePaths: projectDefaults.defaults.sourceCodePaths,
+    extractor: projectDefaults.defaults.extractor,
+    locales: config.outputLocales,
+    extractWorkingDirectory: projectDefaults.defaults.extractor === 'phoenix'
+      ? umbrellaAppDirectory(config.translationFiles.paths)
+      : undefined,
+    pythonInstall
+  });
   workflowCreated = workflowResult.created;
 
   if (workflowCreated && projectDefaults.type === 'lingui') {
     printLinguiWorkflowNotice(console);
+  }
+
+  if (workflowCreated) {
+    printExtractorNotice(projectDefaults.defaults.extractor, console, pythonInstall);
   }
 
   let shouldImport: boolean;

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -587,6 +587,50 @@ export async function findFirstExistingPath(paths: string[], fsModule = fs): Pro
   return null;
 }
 
+// A directory named locale/, locales/ or translations/ is not necessarily a gettext
+// catalog. Wagtail ships a `locales/` Django app and Saleor a `translations/` Python
+// package, both of which a name-only check would wrongly propose. Require the
+// <lang>/LC_MESSAGES/*.po shape that Django and Phoenix actually use.
+const GETTEXT_CATALOG_PATTERN = '*/LC_MESSAGES/*.po';
+
+function catalogRootFromMatch(matchPath: string): string | null {
+  const marker = `${path.sep}LC_MESSAGES${path.sep}`;
+  const normalized = matchPath.split('/').join(path.sep);
+  const idx = normalized.lastIndexOf(marker);
+  if (idx === -1) {
+    return null;
+  }
+  return path.dirname(normalized.slice(0, idx));
+}
+
+export async function findFirstGettextCatalogPath(paths: string[], fsModule = fs): Promise<string | null> {
+  const empties: string[] = [];
+
+  for (const candidate of paths) {
+    const matches = await glob(`${candidate}/${GETTEXT_CATALOG_PATTERN}`);
+    // A candidate may be a pattern (umbrella apps/*/priv/gettext), so derive the
+    // real directory from the match rather than returning the pattern itself.
+    const catalogRoot = matches.length > 0 ? catalogRootFromMatch(matches[0]) : null;
+    if (catalogRoot) {
+      return catalogRoot;
+    }
+    // Only a literal path can be inspected for the greenfield case; an unmatched
+    // pattern has no single directory to fall back to.
+    if (candidate.includes('*') || !(await directoryExists(candidate, fsModule))) {
+      continue;
+    }
+    // An empty directory is a project that has not extracted yet, so it stays a
+    // candidate. A directory with other content and no catalog is something else
+    // wearing the name, and is skipped.
+    const contents = await fsModule.readdir(candidate);
+    if (contents.length === 0) {
+      empties.push(candidate);
+    }
+  }
+
+  return empties[0] ?? null;
+}
+
 /**
  * Get contents of a directory, categorized by file type
  */

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -43,6 +43,136 @@ const defaultDependencies: GitHubDependencies = {
   fetchBranchHead
 };
 
+interface WorkflowOptions {
+  // Which extract step the generated workflow needs. Distinct from the persisted
+  // translationFiles.workflow, which controls Django .po source-file handling.
+  extractor?: string;
+  locales?: string[];
+  // How the project installs Python dependencies, e.g. `uv sync --frozen`.
+  pythonInstall?: string;
+  // Umbrella apps must extract from the child app directory; from the umbrella root
+  // gettext warns about conflicting backends and writes only one app's catalogs.
+  extractWorkingDirectory?: string;
+}
+
+export const DJANGO_PYTHON_VERSION = '3.12';
+
+// Django expects locale names on disk (pt_BR), while config stores language codes
+// (pt-br). Region subtags longer than two characters are titlecase, not uppercase,
+// so sr-latn becomes sr_Latn.
+function toDjangoLocaleName(languageCode: string): string {
+  const [language, region] = languageCode.split(/[-_]/);
+  if (!region) {
+    return language.toLowerCase();
+  }
+  const casedRegion = region.length > 2
+    ? region.charAt(0).toUpperCase() + region.slice(1).toLowerCase()
+    : region.toUpperCase();
+  return `${language.toLowerCase()}_${casedRegion}`;
+}
+
+// `makemessages --all` only picks up locales that already have a directory, so a
+// project with an empty locale/ would extract nothing. Naming the locales explicitly
+// makes it create the catalogs on first run.
+const PIP_INSTALL = 'pip install -r requirements.txt';
+
+// uv and poetry run manage.py through their own environment, so the extract command
+// has to carry the same prefix as the install step.
+function manageRunner(pythonInstall: string): string {
+  if (pythonInstall.startsWith('uv ')) return 'uv run python';
+  if (pythonInstall.startsWith('poetry ')) return 'poetry run python';
+  if (pythonInstall.startsWith('pipenv ')) return 'pipenv run python';
+  return 'python';
+}
+
+function buildMakemessagesCommand(locales?: string[], pythonInstall: string = PIP_INSTALL): string {
+  const runner = manageRunner(pythonInstall);
+  if (!locales?.length) {
+    return `${runner} manage.py makemessages --all`;
+  }
+  const localeFlags = locales.map(l => `-l ${toDjangoLocaleName(l)}`).join(' ');
+  return `${runner} manage.py makemessages ${localeFlags}`;
+}
+
+export const PHOENIX_ELIXIR_VERSION = '1.20';
+export const PHOENIX_OTP_VERSION = '28';
+
+// Gettext-based stacks only see messages that are already in the catalogs, so the
+// workflow has to extract them first. Without this a PR that only touches source
+// code runs green and translates nothing. Extraction is skipped on sync and dispatch
+// runs, where the Action writes reviewed translations back and extraction would
+// fight it.
+// actions/setup-python provides python and pip, nothing else, so a project using
+// uv, poetry or pipenv needs that tool installed before the install command runs.
+const PYTHON_TOOL_SETUP: Record<string, string> = {
+  uv: `      - uses: astral-sh/setup-uv@v5
+        if: github.event_name == 'pull_request'
+
+`,
+  poetry: `      - name: Install poetry
+        if: github.event_name == 'pull_request'
+        run: pipx install poetry
+
+`,
+  pipenv: `      - name: Install pipenv
+        if: github.event_name == 'pull_request'
+        run: pipx install pipenv
+
+`
+};
+
+function buildPythonToolSetup(pythonInstall: string): string {
+  const tool = pythonInstall.split(' ')[0];
+  return PYTHON_TOOL_SETUP[tool] ?? '';
+}
+
+function buildDjangoExtractStep(locales?: string[], pythonInstall: string = PIP_INSTALL): string {
+  return `      - uses: actions/setup-python@v5
+        if: github.event_name == 'pull_request'
+        with:
+          python-version: "${DJANGO_PYTHON_VERSION}"
+
+${buildPythonToolSetup(pythonInstall)}      - name: Extract messages
+        if: github.event_name == 'pull_request'
+        run: |
+          sudo apt-get install -y -qq gettext
+          ${pythonInstall}
+          ${buildMakemessagesCommand(locales, pythonInstall)}
+
+`;
+}
+
+// Elixir's gettext is a pure-Elixir implementation, so no GNU gettext binaries are
+// needed. `gettext.extract` forces its own compile, so deps.get is enough.
+function buildPhoenixExtractStep(workingDirectory?: string): string {
+  const workingDirectoryLine = workingDirectory
+    ? `\n        working-directory: ${workingDirectory}`
+    : '';
+  return `      - uses: erlef/setup-beam@v1
+        if: github.event_name == 'pull_request'
+        with:
+          elixir-version: "${PHOENIX_ELIXIR_VERSION}"
+          otp-version: "${PHOENIX_OTP_VERSION}"
+
+      - name: Extract messages
+        if: github.event_name == 'pull_request'${workingDirectoryLine}
+        run: |
+          mix deps.get
+          mix gettext.extract --merge
+
+`;
+}
+
+function buildExtractStep(options: WorkflowOptions): string {
+  if (options.extractor === 'django') {
+    return buildDjangoExtractStep(options.locales, options.pythonInstall);
+  }
+  if (options.extractor === 'phoenix') {
+    return buildPhoenixExtractStep(options.extractWorkingDirectory);
+  }
+  return '';
+}
+
 const workflowFileName = 'localhero-translate.yml';
 const GIT_USER_NAME = 'LocalHero Bot';
 const GIT_USER_EMAIL = 'hi@localhero.ai';
@@ -94,7 +224,12 @@ export const githubService = {
    * @param basePath Base path of the project
    * @param translationPaths Paths to translation files
    */
-  async createGitHubActionFile(basePath: string, translationPaths: string[], sourceCodePaths?: string[]): Promise<string> {
+  async createGitHubActionFile(
+    basePath: string,
+    translationPaths: string[],
+    sourceCodePaths?: string[],
+    options: WorkflowOptions = {}
+  ): Promise<string> {
     const { fs } = this.deps;
     const workflowDir = this.getWorkflowDir(basePath);
     const workflowFile = this.getGithubActionWorkflowFilePath(basePath);
@@ -139,7 +274,7 @@ jobs:
           ref: \${{ github.event.client_payload.branch || github.head_ref || github.ref_name }}
           fetch-depth: 0
 
-      - name: Translate
+${buildExtractStep(options)}      - name: Translate
         uses: localheroai/localhero-action@v1
         with:
           api-key: \${{ secrets.LOCALHERO_API_KEY }}`;
@@ -585,8 +720,13 @@ jobs:
  * @param basePath Base path of the project
  * @param translationPaths Paths to translation files
  */
-export function createGitHubActionFile(basePath: string, translationPaths: string[], sourceCodePaths?: string[]): Promise<string> {
-  return githubService.createGitHubActionFile(basePath, translationPaths, sourceCodePaths);
+export function createGitHubActionFile(
+  basePath: string,
+  translationPaths: string[],
+  sourceCodePaths?: string[],
+  options?: WorkflowOptions
+): Promise<string> {
+  return githubService.createGitHubActionFile(basePath, translationPaths, sourceCodePaths, options);
 }
 
 /**

--- a/tests/commands/init.test.js
+++ b/tests/commands/init.test.js
@@ -23,6 +23,21 @@ describe('init command', () => {
     };
   }
 
+  let pristineFsStat;
+  let pristineFsReadFile;
+
+  beforeEach(async () => {
+    const fsMod = await import('fs');
+    pristineFsStat = pristineFsStat ?? fsMod.promises.stat;
+    pristineFsReadFile = pristineFsReadFile ?? fsMod.promises.readFile;
+  });
+
+  afterEach(async () => {
+    const fsMod = await import('fs');
+    fsMod.promises.stat = pristineFsStat;
+    fsMod.promises.readFile = pristineFsReadFile;
+  });
+
   beforeEach(() => {
     mockConsole = { log: jest.fn(), warn: console.warn };
     configUtils = {
@@ -756,6 +771,129 @@ describe('init command', () => {
       expect(promptService.confirm).not.toHaveBeenCalled();
     });
 
+  });
+
+  it('passes the django workflow and python source paths to the generated action', async () => {
+    configUtils.getProjectConfig.mockResolvedValue(null);
+    authUtils.checkAuth.mockResolvedValue(true);
+    projectApi.listProjects.mockResolvedValue([]);
+    promptService.selectProject.mockResolvedValue({ choice: 'new' });
+    promptService.input
+      .mockResolvedValueOnce('sv')
+      .mockResolvedValueOnce('en,da,no')
+      .mockResolvedValueOnce('django-project')
+      .mockResolvedValueOnce('locale/')
+      .mockResolvedValueOnce('**/sources/**');
+    projectApi.createProject.mockResolvedValue({
+      id: 'proj_django',
+      name: 'django-project'
+    });
+    const githubUtils = {
+      createGitHubActionFile: jest.fn().mockResolvedValue('.github/workflows/localhero-translate.yml'),
+      workflowExists: jest.fn().mockReturnValue(false)
+    };
+    promptService.confirm
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+
+    const fs = await import('fs');
+    const originalStat = fs.promises.stat;
+    fs.promises.stat = jest.fn().mockImplementation((path) => {
+      if (path === 'manage.py') {
+        return Promise.resolve({ isFile: () => true });
+      }
+      return originalStat(path);
+    });
+
+    await init(createInitDeps({ githubUtils }));
+
+    const [, , sourceCodePaths, options] = githubUtils.createGitHubActionFile.mock.calls[0];
+    expect(options).toEqual({ extractor: 'django', locales: ['en', 'da', 'no'] });
+    expect(sourceCodePaths).toContain('**/*.py');
+    expect(sourceCodePaths).toContain('**/*.html');
+
+    fs.promises.stat = originalStat;
+  });
+
+  it('does not infer phoenix when mix.exs is not at the repository root', async () => {
+    configUtils.getProjectConfig.mockResolvedValue({
+      schemaVersion: '1.0',
+      projectId: 'proj_existing_phx',
+      sourceLocale: 'en',
+      outputLocales: ['sv'],
+      lastSyncedAt: '2026-08-01T00:00:00Z',
+      translationFiles: { paths: ['apps/myapp_web/priv/gettext/'], pattern: '**/*.po' }
+    });
+    authUtils.checkAuth.mockResolvedValue(true);
+    const githubUtils = {
+      createGitHubActionFile: jest.fn().mockResolvedValue('.github/workflows/localhero-translate.yml'),
+      workflowExists: jest.fn().mockReturnValue(false)
+    };
+    promptService.confirm.mockResolvedValue(true);
+
+    await init(createInitDeps({ githubUtils, options: { skipImport: true } }));
+
+    const [, , , options] = githubUtils.createGitHubActionFile.mock.calls[0];
+    expect(options.extractor).toBeUndefined();
+  });
+
+  it('passes the phoenix extractor and umbrella source paths to the generated action', async () => {
+    configUtils.getProjectConfig.mockResolvedValue(null);
+    authUtils.checkAuth.mockResolvedValue(true);
+    projectApi.listProjects.mockResolvedValue([]);
+    promptService.selectProject.mockResolvedValue({ choice: 'new' });
+    promptService.input
+      .mockResolvedValueOnce('en')
+      .mockResolvedValueOnce('sv,nb')
+      .mockResolvedValueOnce('phoenix-project')
+      .mockResolvedValueOnce('priv/gettext/')
+      .mockResolvedValueOnce('');
+    projectApi.createProject.mockResolvedValue({ id: 'proj_phoenix', name: 'phoenix-project' });
+    const githubUtils = {
+      createGitHubActionFile: jest.fn().mockResolvedValue('.github/workflows/localhero-translate.yml'),
+      workflowExists: jest.fn().mockReturnValue(false)
+    };
+    promptService.confirm
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+
+    const fs = await import('fs');
+    fs.promises.stat = jest.fn().mockImplementation((path) =>
+      path === 'mix.exs'
+        ? Promise.resolve({ isFile: () => true })
+        : Promise.reject(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }))
+    );
+
+    await init(createInitDeps({ githubUtils }));
+
+    const [, , sourceCodePaths, options] = githubUtils.createGitHubActionFile.mock.calls[0];
+    expect(options.extractor).toBe('phoenix');
+    expect(sourceCodePaths).toContain('lib/**/*.heex');
+    expect(sourceCodePaths).toContain('apps/*/lib/**/*.ex');
+    expect(sourceCodePaths).toContain('lib/**/*.leex');
+  });
+
+  it('does not infer django when manage.py is not at the repository root', async () => {
+    configUtils.getProjectConfig.mockResolvedValue({
+      schemaVersion: '1.0',
+      projectId: 'proj_existing',
+      sourceLocale: 'en',
+      outputLocales: ['sv'],
+      lastSyncedAt: '2026-08-01T00:00:00Z',
+      translationFiles: { paths: ['translations/'], pattern: '**/*.po', workflow: 'django' }
+    });
+    authUtils.checkAuth.mockResolvedValue(true);
+    const githubUtils = {
+      createGitHubActionFile: jest.fn().mockResolvedValue('.github/workflows/localhero-translate.yml'),
+      workflowExists: jest.fn().mockReturnValue(false)
+    };
+    promptService.confirm.mockResolvedValue(true);
+
+    await init(createInitDeps({ githubUtils, options: { skipImport: true } }));
+
+    const [, , sourceCodePaths, options] = githubUtils.createGitHubActionFile.mock.calls[0];
+    expect(options.extractor).toBeUndefined();
+    expect(sourceCodePaths).toBeUndefined();
   });
 
   it('configures Django workflow for Django projects', async () => {

--- a/tests/utils/files.test.js
+++ b/tests/utils/files.test.js
@@ -14,6 +14,7 @@ describe('files utils', () => {
   let mockFs;
   let directoryExists;
   let findFirstExistingPath;
+  let findFirstGettextCatalogPath;
   let getDirectoryContents;
 
   beforeEach(async () => {
@@ -51,6 +52,7 @@ describe('files utils', () => {
     preserveJsonStructure = filesModule.preserveJsonStructure;
     directoryExists = filesModule.directoryExists;
     findFirstExistingPath = filesModule.findFirstExistingPath;
+    findFirstGettextCatalogPath = filesModule.findFirstGettextCatalogPath;
     getDirectoryContents = filesModule.getDirectoryContents;
   });
 
@@ -1223,6 +1225,116 @@ en:
       const result = await findFirstExistingPath(paths, mockFs);
       expect(result).toBe(null);
       expect(mockFs.stat).toHaveBeenCalledTimes(3); // Should check all paths
+    });
+  });
+
+  describe('findFirstGettextCatalogPath', () => {
+    const existsEverywhere = () => {
+      mockFs.stat.mockImplementation(() => Promise.resolve({ isDirectory: () => true }));
+      mockFs.readdir.mockResolvedValue(['some-file.py']);
+    };
+
+    it('skips a directory that exists but holds no catalog', async () => {
+      existsEverywhere();
+      mockGlob.mockImplementation((pattern) =>
+        pattern.startsWith('locale/') ? Promise.resolve(['locale/sv/LC_MESSAGES/django.po']) : Promise.resolve([])
+      );
+
+      const result = await findFirstGettextCatalogPath(['translations', 'locale'], mockFs);
+      expect(result).toBe('locale');
+    });
+
+    it('accepts a translations directory that does hold a catalog', async () => {
+      existsEverywhere();
+      mockGlob.mockImplementation((pattern) =>
+        pattern.startsWith('translations/')
+          ? Promise.resolve(['translations/sv/LC_MESSAGES/django.po'])
+          : Promise.resolve([])
+      );
+
+      const result = await findFirstGettextCatalogPath(['translations', 'locale'], mockFs);
+      expect(result).toBe('translations');
+    });
+
+    it('accepts an empty candidate directory so greenfield projects still work', async () => {
+      existsEverywhere();
+      mockFs.readdir.mockResolvedValue([]);
+      mockGlob.mockResolvedValue([]);
+
+      const result = await findFirstGettextCatalogPath(['locale', 'translations'], mockFs);
+      expect(result).toBe('locale');
+    });
+
+    it('rejects a non-empty directory that holds no catalog', async () => {
+      existsEverywhere();
+      mockFs.readdir.mockImplementation((dir) =>
+        dir === 'locales' ? Promise.resolve(['apps.py', 'views.py']) : Promise.resolve([])
+      );
+      mockGlob.mockResolvedValue([]);
+
+      const result = await findFirstGettextCatalogPath(['locales', 'translations'], mockFs);
+      expect(result).toBe('translations');
+    });
+
+    it('finds an umbrella catalog under apps/*/priv/gettext', async () => {
+      mockFs.stat.mockImplementation((dir) =>
+        dir === 'apps/myapp_web/priv/gettext'
+          ? Promise.resolve({ isDirectory: () => true })
+          : Promise.reject(Object.assign(new Error('nope'), { code: 'ENOENT' }))
+      );
+      mockFs.readdir.mockResolvedValue(['sv']);
+      mockGlob.mockImplementation((pattern) =>
+        pattern.startsWith('apps/*/priv/gettext')
+          ? Promise.resolve(['apps/myapp_web/priv/gettext/sv/LC_MESSAGES/default.po'])
+          : Promise.resolve([])
+      );
+
+      const result = await findFirstGettextCatalogPath(['priv/gettext', 'apps/*/priv/gettext'], mockFs);
+      expect(result).toBe('apps/myapp_web/priv/gettext');
+    });
+
+    it('returns null when no candidate holds a catalog', async () => {
+      existsEverywhere();
+      mockGlob.mockResolvedValue([]);
+
+      mockFs.readdir.mockResolvedValue(['apps.py']);
+      const result = await findFirstGettextCatalogPath(['translations', 'locale'], mockFs);
+      expect(result).toBe(null);
+    });
+  });
+
+  describe('greenfield fallback ordering', () => {
+    it('prefers an empty candidate over a non-empty non-catalog directory', async () => {
+      mockFs.stat.mockImplementation((dir) =>
+        dir === 'locales' || dir === 'translations'
+          ? Promise.resolve({ isDirectory: () => true })
+          : Promise.reject(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }))
+      );
+      mockFs.readdir.mockImplementation((dir) =>
+        dir === 'locales' ? Promise.resolve(['apps.py', 'views.py']) : Promise.resolve([])
+      );
+      mockGlob.mockResolvedValue([]);
+
+      const result = await findFirstGettextCatalogPath(['locale', 'locales', 'translations'], mockFs);
+      expect(result).toBe('translations');
+    });
+  });
+
+  describe('catalog root derivation', () => {
+    it('uses the catalog LC_MESSAGES, not an unrelated one higher in the tree', async () => {
+      mockFs.stat.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
+      mockGlob.mockResolvedValue(['foo/LC_MESSAGES/bar/priv/gettext/sv/LC_MESSAGES/x.po']);
+
+      const result = await findFirstGettextCatalogPath(['**/priv/gettext'], mockFs);
+      expect(result).toBe('foo/LC_MESSAGES/bar/priv/gettext');
+    });
+
+    it('ignores a match that has no LC_MESSAGES segment', async () => {
+      mockFs.stat.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
+      mockGlob.mockResolvedValue(['weird/path/without-marker.po']);
+
+      const result = await findFirstGettextCatalogPath(['weird/path'], mockFs);
+      expect(result).toBe(null);
     });
   });
 

--- a/tests/utils/github.test.ts
+++ b/tests/utils/github.test.ts
@@ -138,6 +138,145 @@ describe('githubService', () => {
       expect(fileContent).toContain('- "i18n/*.json"');
     });
 
+    it('adds a makemessages extract step for django projects', async () => {
+      await createGitHubActionFile('/project', ['locale/**'], undefined, {
+        extractor: 'django',
+        locales: ['sv', 'de']
+      });
+
+      const fileContent = (mockFs.writeFile.mock.calls[0] as unknown[])[1] as string;
+      expect(fileContent).toContain('uses: actions/setup-python@v5');
+      expect(fileContent).toContain('sudo apt-get install -y -qq gettext');
+      expect(fileContent).toContain('python manage.py makemessages -l sv -l de');
+      expect(fileContent).not.toContain('--no-obsolete');
+      expect(fileContent.indexOf('makemessages')).toBeLessThan(
+        fileContent.indexOf('uses: localheroai/localhero-action@v1')
+      );
+    });
+
+    it('converts language codes to django locale names in the extract step', async () => {
+      await createGitHubActionFile('/project', ['locale/**'], undefined, {
+        extractor: 'django',
+        locales: ['pt-br', 'de-at', 'en']
+      });
+
+      const fileContent = (mockFs.writeFile.mock.calls[0] as unknown[])[1] as string;
+      expect(fileContent).toContain('makemessages -l pt_BR -l de_AT -l en');
+    });
+
+    it('falls back to --all when no locales are known', async () => {
+      await createGitHubActionFile('/project', ['locale/**'], undefined, { extractor: 'django' });
+
+      const fileContent = (mockFs.writeFile.mock.calls[0] as unknown[])[1] as string;
+      expect(fileContent).toContain('python manage.py makemessages --all');
+    });
+
+    it('skips extraction on sync and dispatch runs', async () => {
+      await createGitHubActionFile('/project', ['locale/**'], undefined, {
+        extractor: 'django',
+        locales: ['sv']
+      });
+
+      const fileContent = (mockFs.writeFile.mock.calls[0] as unknown[])[1] as string;
+      expect(fileContent).toContain("if: github.event_name == 'pull_request'");
+    });
+
+    it('uses uv when the project has a uv lockfile', async () => {
+      await createGitHubActionFile('/project', ['locale/**'], undefined, {
+        extractor: 'django',
+        locales: ['sv'],
+        pythonInstall: 'uv sync --frozen'
+      });
+
+      const fileContent = (mockFs.writeFile.mock.calls[0] as unknown[])[1] as string;
+      expect(fileContent).toContain('uv sync --frozen');
+      expect(fileContent).toContain('uv run python manage.py makemessages -l sv');
+      expect(fileContent).not.toContain('pip install');
+    });
+
+    it('installs uv before using it', async () => {
+      await createGitHubActionFile('/project', ['locale/**'], undefined, {
+        extractor: 'django',
+        locales: ['sv'],
+        pythonInstall: 'uv sync --frozen'
+      });
+
+      const fileContent = (mockFs.writeFile.mock.calls[0] as unknown[])[1] as string;
+      expect(fileContent).toContain('astral-sh/setup-uv@v5');
+      expect(fileContent.indexOf('setup-uv')).toBeLessThan(fileContent.indexOf('uv sync'));
+    });
+
+    it('does not add a uv setup step for pip projects', async () => {
+      await createGitHubActionFile('/project', ['locale/**'], undefined, {
+        extractor: 'django',
+        locales: ['sv']
+      });
+
+      const fileContent = (mockFs.writeFile.mock.calls[0] as unknown[])[1] as string;
+      expect(fileContent).not.toContain('setup-uv');
+    });
+
+    it('falls back to pip when no other manifest is present', async () => {
+      await createGitHubActionFile('/project', ['locale/**'], undefined, {
+        extractor: 'django',
+        locales: ['sv']
+      });
+
+      const fileContent = (mockFs.writeFile.mock.calls[0] as unknown[])[1] as string;
+      expect(fileContent).toContain('pip install -r requirements.txt');
+      expect(fileContent).toContain('python manage.py makemessages -l sv');
+      expect(fileContent).not.toContain('uv run');
+    });
+
+    it('adds a gettext extract step for phoenix projects', async () => {
+      await createGitHubActionFile('/project', ['priv/gettext/**'], undefined, { extractor: 'phoenix' });
+
+      const fileContent = (mockFs.writeFile.mock.calls[0] as unknown[])[1] as string;
+      expect(fileContent).toContain('uses: erlef/setup-beam@v1');
+      expect(fileContent).toContain('mix deps.get');
+      expect(fileContent).toContain('mix gettext.extract --merge');
+      expect(fileContent).toContain("if: github.event_name == 'pull_request'");
+      expect(fileContent.indexOf('gettext.extract')).toBeLessThan(
+        fileContent.indexOf('uses: localheroai/localhero-action@v1')
+      );
+    });
+
+    it('runs the phoenix extract step inside the app dir for umbrella projects', async () => {
+      await createGitHubActionFile('/project', ['apps/myapp_web/priv/gettext/**'], undefined, {
+        extractor: 'phoenix',
+        extractWorkingDirectory: 'apps/myapp_web'
+      });
+
+      const fileContent = (mockFs.writeFile.mock.calls[0] as unknown[])[1] as string;
+      expect(fileContent).toContain('working-directory: apps/myapp_web');
+      expect(fileContent).toContain('mix gettext.extract --merge');
+    });
+
+    it('omits working-directory for a plain phoenix project', async () => {
+      await createGitHubActionFile('/project', ['priv/gettext/**'], undefined, { extractor: 'phoenix' });
+
+      const fileContent = (mockFs.writeFile.mock.calls[0] as unknown[])[1] as string;
+      expect(fileContent).not.toContain('working-directory');
+    });
+
+    it('does not install gettext system packages for phoenix', async () => {
+      await createGitHubActionFile('/project', ['priv/gettext/**'], undefined, { extractor: 'phoenix' });
+
+      const fileContent = (mockFs.writeFile.mock.calls[0] as unknown[])[1] as string;
+      expect(fileContent).not.toContain('apt-get');
+      expect(fileContent).not.toContain('makemessages');
+    });
+
+    it('does not add an extract step for rails and other key-based projects', async () => {
+      await createGitHubActionFile('/project', ['config/locales/**']);
+
+      const fileContent = (mockFs.writeFile.mock.calls[0] as unknown[])[1] as string;
+      expect(fileContent).not.toContain('makemessages');
+      expect(fileContent).not.toContain('actions/setup-python');
+      expect(fileContent).not.toContain('setup-beam');
+      expect(fileContent).not.toContain('gettext.extract');
+    });
+
     it('writes sourceCodePaths as literal patterns without brace expansion', async () => {
       const sourceCodePaths = ['src/**/*.ts', 'src/**/*.tsx', 'src/**/*.js', 'src/**/*.jsx'];
       await createGitHubActionFile('/project', ['src/locales/**'], sourceCodePaths);


### PR DESCRIPTION
- Generate an extract step (makemessages / mix gettext.extract --merge) before the translate step and watch source files so such a PR triggers the workflow at all.
- Name Django's target locales explicitly instead of --all, which only enumerates locales that already have a directory and writes nothing on a project that has not extracted yet.
- Read the dependency manager from the lockfile, and install it. uv, poetry and pipenv need their own run prefix.
- Extract from the child app in Phoenix umbrellas. From the umbrella root gettext warns that the backends share a :priv directory and writes only one app's catalogs.
- Require a <lang>/LC_MESSAGES/*.po match when detecting a catalog, so a Django app named locales/ or a Python package named translations/ is no longer proposed.