### PR TITLE
Never write translation keys the run did not request

### DIFF
--- a/src/utils/translation-processor.ts
+++ b/src/utils/translation-processor.ts
@@ -321,18 +321,31 @@ async function applyTranslations(
   const entry = missingByLocale[localeSourceKey];
   const targetPath = entry.targetPath;
   const fileLocale = localeSourceKey.slice(0, localeSourceKey.indexOf(':')) || languageCode;
+  // Only write keys this run asked for.
+  const returnedTranslations = Object.entries(data.translations.data);
+  const requestedTranslations = returnedTranslations.filter(([key]) => Object.hasOwn(entry.keys, key));
+  const unrequestedCount = returnedTranslations.length - requestedTranslations.length;
+
+  if (verbose && unrequestedCount > 0) {
+    console.log(chalk.gray(`    Ignored ${unrequestedCount} key(s) not requested for ${languageCode}; local values kept`));
+  }
+
+  if (requestedTranslations.length === 0) {
+    return false;
+  }
+
   if (verbose) {
     console.log(chalk.blue(`  Updating translations for ${languageCode} in ${targetPath}`));
   }
 
   const isPoFile = /\.(po|pot)$/i.test(targetPath);
   const translationsToWrite = isPoFile
-    ? Object.entries(data.translations.data).map(([key, value]) => ({
+    ? requestedTranslations.map(([key, value]) => ({
       key,
       value,
       ...(entry.keys[key]?.metadata && { metadata: entry.keys[key].metadata })
     }))
-    : data.translations.data;
+    : Object.fromEntries(requestedTranslations);
 
   const result = await translationUtils.updateTranslationFile(
     targetPath,

--- a/tests/utils/translation-processor.test.js
+++ b/tests/utils/translation-processor.test.js
@@ -888,4 +888,159 @@ describe('translation-processor', () => {
       }
     });
   });
+
+  describe('preserving local target values (#508)', () => {
+    const config = { projectId: 'test-project' };
+
+    const buildBatch = (extension, format) => ([
+      {
+        sourceFilePath: `locales/en.${extension}`,
+        sourceFile: {
+          path: `locales/en.${extension}`,
+          format,
+          content: Buffer.from(JSON.stringify({ keys: {} })).toString('base64')
+        },
+        localeEntries: [`sv:locales/en.${extension}`],
+        locales: ['sv']
+      }
+    ]);
+
+    const buildMissing = (extension, keys) => ({
+      [`sv:locales/en.${extension}`]: {
+        locale: 'sv',
+        path: `locales/en.${extension}`,
+        targetPath: `locales/sv.${extension}`,
+        keys,
+        keyCount: Object.keys(keys).length
+      }
+    });
+
+    it('does not write back keys the CLI never asked for', async () => {
+      mockTranslationUtils.createTranslationJob.mockResolvedValue({
+        jobs: [{ id: 'job-508', language: { code: 'sv' } }]
+      });
+
+      mockTranslationUtils.checkJobStatus.mockResolvedValue({
+        status: 'completed',
+        translations: {
+          data: {
+            'pages.docs.nav.remove': 'Ta bort nycklar och språkområden',
+            'pages.docs.nav.agents': 'AI-agenter',
+            'pages.docs.nav.new': 'Ny sida'
+          }
+        },
+        language: { code: 'sv' }
+      });
+
+      const result = await processTranslationBatches(
+        buildBatch('yml', 'yaml'),
+        buildMissing('yml', {
+          'pages.docs.nav.new': { value: 'New page', sourceKey: 'pages.docs.nav.new' }
+        }),
+        config,
+        true,
+        { console: mockConsole, translationUtils: mockTranslationUtils }
+      );
+
+      expect(mockTranslationUtils.updateTranslationFile).toHaveBeenCalledWith(
+        'locales/sv.yml',
+        { 'pages.docs.nav.new': 'Ny sida' },
+        'sv',
+        'locales/en.yml',
+        undefined,
+        config
+      );
+      expect(result.uniqueKeysTranslated.size).toBe(1);
+      expect(result.uniqueKeysTranslated.has('pages.docs.nav.new')).toBe(true);
+    });
+
+    it('skips the write entirely when every returned key was unrequested', async () => {
+      mockTranslationUtils.createTranslationJob.mockResolvedValue({
+        jobs: [{ id: 'job-508b', language: { code: 'sv' } }]
+      });
+
+      mockTranslationUtils.checkJobStatus.mockResolvedValue({
+        status: 'completed',
+        translations: {
+          data: { 'pages.docs.nav.remove': 'Ta bort nycklar och språkområden' }
+        },
+        language: { code: 'sv' }
+      });
+
+      const result = await processTranslationBatches(
+        buildBatch('yml', 'yaml'),
+        buildMissing('yml', {
+          'pages.docs.nav.new': { value: 'New page', sourceKey: 'pages.docs.nav.new' }
+        }),
+        config,
+        true,
+        { console: mockConsole, translationUtils: mockTranslationUtils }
+      );
+
+      expect(mockTranslationUtils.updateTranslationFile).not.toHaveBeenCalled();
+      expect(result.uniqueKeysTranslated.size).toBe(0);
+    });
+
+    it('filters unrequested keys for .po targets too', async () => {
+      mockTranslationUtils.createTranslationJob.mockResolvedValue({
+        jobs: [{ id: 'job-508c', language: { code: 'sv' } }]
+      });
+
+      mockTranslationUtils.checkJobStatus.mockResolvedValue({
+        status: 'completed',
+        translations: {
+          data: { Welcome: 'Välkommen', Goodbye: 'Hej då' }
+        },
+        language: { code: 'sv' }
+      });
+
+      await processTranslationBatches(
+        buildBatch('po', 'po'),
+        buildMissing('po', { Welcome: { value: 'Welcome', sourceKey: 'Welcome' } }),
+        config,
+        true,
+        { console: mockConsole, translationUtils: mockTranslationUtils }
+      );
+
+      expect(mockTranslationUtils.updateTranslationFile).toHaveBeenCalledWith(
+        'locales/sv.po',
+        [{ key: 'Welcome', value: 'Välkommen' }],
+        'sv',
+        'locales/en.po',
+        undefined,
+        config
+      );
+    });
+
+    it('does not write an unrequested key that shadows an Object prototype member', async () => {
+      mockTranslationUtils.createTranslationJob.mockResolvedValue({
+        jobs: [{ id: 'job-508d', language: { code: 'sv' } }]
+      });
+
+      mockTranslationUtils.checkJobStatus.mockResolvedValue({
+        status: 'completed',
+        translations: {
+          data: { constructor: 'Konstruktor', toString: 'Till text', greeting: 'Hej' }
+        },
+        language: { code: 'sv' }
+      });
+
+      await processTranslationBatches(
+        buildBatch('json', 'json'),
+        buildMissing('json', { greeting: { value: 'Hello', sourceKey: 'greeting' } }),
+        config,
+        true,
+        { console: mockConsole, translationUtils: mockTranslationUtils }
+      );
+
+      expect(mockTranslationUtils.updateTranslationFile).toHaveBeenCalledWith(
+        'locales/sv.json',
+        { greeting: 'Hej' },
+        'sv',
+        'locales/en.json',
+        undefined,
+        config
+      );
+    });
+  });
 });


### PR DESCRIPTION
Fixes #508: `translate` silently overwrote hand-written local target values for keys that were new to the backend.

- The missing-check already respects non-empty local values, so such keys never reach `entry.keys`. The apply step ignored that and wrote the whole backend payload to disk, clobbering local work.
- Filter the payload down to requested keys before writing, for both the .po array path and the JSON/YAML record path.
- Skip the write and the "updating" log entirely when nothing requested came back.
- Use `Object.hasOwn` so a key named `constructor` or `toString` cannot pass the check via the prototype chain.